### PR TITLE
Evaluate each frame

### DIFF
--- a/evaluate/eval_funcs.py
+++ b/evaluate/eval_funcs.py
@@ -2,6 +2,7 @@ import numpy as np
 import tensorflow as tf
 import settings
 import utils.convert_pose as cp
+from utils.decorators import ShapeCheck
 
 
 def compute_depth_metrics(gt, pred):
@@ -100,26 +101,28 @@ def calc_rotational_error(pose_pred_mat, pose_true_mat):
     return angle
 
 
+@ShapeCheck
 def calc_trajectory_error_tensor(pose_pred_mat, pose_true_mat):
     """
-    :param pose_pred_mat: predicted snippet pose matrices, [batch, ?, 4, 4]
-    :param pose_true_mat: ground truth snippet pose matrices, [batch, ?, 4, 4]
-    :return: trajectory error in meter [snippet_len]
+    :param pose_pred_mat: predicted snippet pose matrices, [batch, num_src, 4, 4]
+    :param pose_true_mat: ground truth snippet pose matrices, [batch, num_src, 4, 4]
+    :return: trajectory error in meter [batch, num_src]
     """
     xyz_pred = pose_pred_mat[:, :, :3, 3]
     xyz_true = pose_true_mat[:, :, :3, 3]
-    # optimize the scaling factor
+    # adjust the trajectory scaling due to ignorance of abolute scale
     scale = tf.reduce_sum(xyz_true * xyz_pred, axis=2) / tf.reduce_sum(xyz_pred ** 2, axis=2)
     traj_error = xyz_true - xyz_pred * tf.expand_dims(scale, -1)
     traj_error = tf.sqrt(tf.reduce_sum(traj_error ** 2, axis=2))
     return traj_error
 
 
+@ShapeCheck
 def calc_rotational_error_tensor(pose_pred_mat, pose_true_mat):
     """
-    :param pose_pred_mat: predicted snippet pose matrices w.r.t the first frame, [batch, ?, 4, 4]
-    :param pose_true_mat: ground truth snippet pose matrices w.r.t the first frame, [batch, ?, 4, 4]
-    :return: rotational error in rad [snippet_len]
+    :param pose_pred_mat: predicted snippet pose matrices w.r.t the first frame, [batch, num_src, 4, 4]
+    :param pose_true_mat: ground truth snippet pose matrices w.r.t the first frame, [batch, num_src, 4, 4]
+    :return: rotational error in rad [batch, num_src]
     """
     rot_pred = pose_pred_mat[:, :, :3, :3]
     rot_true = pose_true_mat[:, :, :3, :3]

--- a/evaluate/eval_funcs.py
+++ b/evaluate/eval_funcs.py
@@ -17,7 +17,7 @@ def compute_depth_metrics(gt, pred):
     rmse_log = (np.log(gt) - np.log(pred)) ** 2
     rmse_log = np.sqrt(rmse_log.mean())
 
-    abs_rel = np.mean((gt - pred) / gt)
+    abs_rel = np.mean(np.abs(gt - pred) / gt)
 
     sq_rel = np.mean(((gt - pred)**2) / gt)
 

--- a/evaluate/eval_funcs.py
+++ b/evaluate/eval_funcs.py
@@ -17,7 +17,7 @@ def compute_depth_metrics(gt, pred):
     rmse_log = (np.log(gt) - np.log(pred)) ** 2
     rmse_log = np.sqrt(rmse_log.mean())
 
-    abs_rel = np.mean(np.abs(gt - pred) / gt)
+    abs_rel = np.mean((gt - pred) / gt)
 
     sq_rel = np.mean(((gt - pred)**2) / gt)
 

--- a/evaluate/evaluate_debug.py
+++ b/evaluate/evaluate_debug.py
@@ -3,6 +3,7 @@ import os.path as op
 import numpy as np
 import pandas as pd
 import cv2
+import tensorflow as tf
 
 import settings
 from config import opts
@@ -10,7 +11,6 @@ from tfrecords.tfrecord_reader import TfrecordGenerator
 import utils.util_funcs as uf
 import utils.convert_pose as cp
 import evaluate.eval_funcs as ef
-from evaluate.evaluate_main import evaluate_depth
 from model.synthesize_batch import synthesize_batch_multi_scale
 from model.loss_and_metric import photometric_loss, smootheness_loss
 from model.model_main import set_configs, create_model, try_load_weights
@@ -25,34 +25,35 @@ def evaluate_for_debug(data_dir_name, model_name):
     dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1).get_generator()
     depth_result = []
     pose_result = []
+    trajectory = []
     steps_per_epoch = uf.count_steps(data_dir_name, 1)
 
     for i, x in enumerate(dataset):
         uf.print_numeric_progress(i, steps_per_epoch)
-        depth_res, pose_res = evaluate_batch(i, x, model)
+        depth_res, pose_res, traj = evaluate_batch(i, x, model)
         depth_result.append(depth_res)
         pose_result.append(pose_res)
+        trajectory.append(traj)
 
     print("")
     depth_result = save_depth_result_and_get_df(depth_result, model_name)
-    print("depth_result\n", depth_result.head(10))
     pose_result = save_pose_result_and_get_df(pose_result, model_name)
-    print("pose_result\n", pose_result.head(10))
+    save_trajectories(trajectory, model_name)
 
     depth_sample_inds = find_worst_depth_samples(depth_result, 5)
-    print("depth sample indices\n", depth_sample_inds[0])
+    print("worst depth sample indices\n", depth_sample_inds[0])
     pose_sample_inds = find_worst_pose_samples(pose_result, 5)
-    print("pose sample indices\n", pose_sample_inds[0])
+    print("worst pose sample indices\n", pose_sample_inds[0])
+    worst_sample_inds = depth_sample_inds + pose_sample_inds
 
     pathname = op.join(opts.DATAPATH_EVL, model_name, 'debug_imgs')
     os.makedirs(pathname, exist_ok=True)
 
     for i, x in enumerate(dataset):
         uf.print_numeric_progress(i, steps_per_epoch)
-        for sample_inds in depth_sample_inds:
-            save_worst_depth_view(i, x, model, sample_inds, pathname)
-        for sample_inds in pose_sample_inds:
-            save_worst_pose_view(i, x, model, sample_inds, pathname)
+        for sample_inds in worst_sample_inds:
+            # sample_inds: df['frame', 'srcidx', metric or loss]
+            save_worst_views(i, x, model, sample_inds, pathname)
 
 
 def evaluate_batch(index, x, model):
@@ -70,24 +71,28 @@ def evaluate_batch(index, x, model):
     depth_pred_ms = uf.disp_to_depth_tensor(disp_pred_ms)
 
     # evaluate depth from numpy arrays and take only 'abs_rel' metric
-    depth_err = evaluate_depth(depth_pred_ms[0].numpy()[0], depth_true.numpy()[0])
-    depth_err = depth_err[0]
+    depth_err, scale = compute_depth_error(depth_pred_ms[0].numpy()[0], depth_true.numpy()[0])
     smooth_loss = compute_smooth_loss(disp_pred_ms[0], target_image)
 
-    snp_res = [index, smooth_loss, depth_err]
-
-    # evaluate poses
     pose_pred_mat = cp.pose_rvec2matr_batch(pose_pred)
     # pose error output: [batch, num_src]
-    trj_err = ef.calc_trajectory_error_tensor(pose_pred_mat, pose_true_mat)
+    trj_err, trj_len = compute_trajectory_error(pose_pred_mat, pose_true_mat, scale)
     rot_err = ef.calc_rotational_error_tensor(pose_pred_mat, pose_true_mat)
+
     # compute photometric loss: [batch, num_src]
     photo_loss = compute_photo_loss(target_image, source_image, intrinsic, depth_pred_ms, pose_pred)
 
-    # src_res: [num_src, -1]
-    src_res = np.stack([np.array([index] * 4), np.arange(num_src), photo_loss.numpy().reshape(-1),
-                        trj_err.numpy().reshape(-1), rot_err.numpy().reshape(-1)], axis=1)
-    return snp_res, src_res
+    depth_res = [index, smooth_loss, depth_err]
+    # pose_res: [num_src, -1]
+    pose_res = np.stack([np.array([index] * 4), np.arange(num_src), photo_loss.numpy().reshape(-1),
+                         trj_err.numpy().reshape(-1), trj_len.numpy().reshape(-1),
+                         rot_err.numpy().reshape(-1)], axis=1)
+
+    # to collect trajectory
+    trajectory = np.concatenate([np.array([index] * 4)[:, np.newaxis], np.arange(num_src)[:, np.newaxis],
+                                 pose_true_mat.numpy()[:, :, :3, 3].reshape((-1, 3)),
+                                 pose_pred_mat.numpy()[:, :, :3, 3].reshape((-1, 3))*scale], axis=1)
+    return depth_res, pose_res, trajectory
 
 
 def compute_photo_loss(target_true, source_image, intrinsic, depth_pred_ms, pose_pred):
@@ -107,6 +112,43 @@ def compute_smooth_loss(disparity, target_image):
     return loss.numpy()[0]
 
 
+def compute_trajectory_error(pose_pred_mat, pose_true_mat, scale):
+    """
+    :param pose_pred_mat: predicted snippet pose matrices, [batch, num_src, 4, 4]
+    :param pose_true_mat: ground truth snippet pose matrices, [batch, num_src, 4, 4]
+    :param scale: scale for pose_pred to have real scale
+    :return: trajectory error in meter [batch, num_src]
+    """
+    xyz_pred = pose_pred_mat[:, :, :3, 3]
+    xyz_true = pose_true_mat[:, :, :3, 3]
+    # adjust the trajectory scaling due to ignorance of abolute scale
+    # scale = tf.reduce_sum(xyz_true * xyz_pred, axis=2) / tf.reduce_sum(xyz_pred ** 2, axis=2)
+    # scale = tf.expand_dims(scale, -1)
+    traj_error = xyz_true - xyz_pred * tf.constant([[[scale]]])
+    traj_error = tf.sqrt(tf.reduce_sum(traj_error ** 2, axis=2))
+    traj_len = tf.sqrt(tf.reduce_sum(xyz_true ** 2, axis=2))
+    return traj_error, traj_len
+
+
+def compute_depth_error(depth_pred, depth_true):
+    mask = np.logical_and(depth_true > opts.MIN_DEPTH, depth_true < opts.MAX_DEPTH)
+    # crop used by Garg ECCV16 to reprocude Eigen NIPS14 results
+    # if used on gt_size 370x1224 produces a crop of [-218, -3, 44, 1180]
+    gt_height, gt_width, _ = depth_true.shape
+    crop = np.array([0.40810811 * gt_height, 0.99189189 * gt_height,
+                     0.03594771 * gt_width, 0.96405229 * gt_width]).astype(np.int32)
+    crop_mask = np.zeros(mask.shape)
+    crop_mask[crop[0]:crop[1], crop[2]:crop[3]] = 1
+    mask = np.logical_and(mask, crop_mask)
+    # scale matching
+    scaler = np.median(depth_true[mask]) / np.median(depth_pred[mask])
+    depth_pred[mask] *= scaler
+    # clip prediction and compute error metrics
+    depth_pred = np.clip(depth_pred, opts.MIN_DEPTH, opts.MAX_DEPTH)
+    metrics = ef.compute_depth_metrics(depth_true[mask], depth_pred[mask])
+    # return only abs rel
+    return metrics[0], scaler
+
 def save_depth_result_and_get_df(depth_result, model_name):
     depth_result = np.array(depth_result)
     depth_result = pd.DataFrame(data=depth_result, columns=['frame', 'smooth_loss', 'depth_err'])
@@ -118,34 +160,47 @@ def save_depth_result_and_get_df(depth_result, model_name):
 
 def save_pose_result_and_get_df(pose_result, model_name):
     pose_result = np.concatenate(pose_result, axis=0)
-    columns = ['frame', 'source', 'photo_loss', 'trj_err', 'rot_err']
+    columns = ['frame', 'srcidx', 'photo_loss', 'trj_err', 'distance', 'rot_err']
     pose_result = pd.DataFrame(data=pose_result, columns=columns)
     pose_result['frame'] = pose_result['frame'].astype(int)
-    pose_result['source'] = pose_result['source'].astype(int)
+    pose_result['srcidx'] = pose_result['srcidx'].astype(int)
     filename = op.join(opts.DATAPATH_EVL, model_name, 'debug_pose.csv')
     pose_result.to_csv(filename, encoding='utf-8', index=False, float_format='%.4f')
     return pose_result
 
 
+def save_trajectories(trajectory, model_name):
+    trajectory = np.concatenate(trajectory, axis=0)
+    trajectory = pd.DataFrame(data=trajectory, columns=['frame', 'srcidx', 'tx', 'ty', 'tz', 'px', 'py', 'pz'])
+    trajectory['frame'] = trajectory['frame'].astype(int)
+    trajectory['srcidx'] = trajectory['srcidx'].astype(int)
+    filename = op.join(opts.DATAPATH_EVL, model_name, 'trajectory.csv')
+    trajectory.to_csv(filename, encoding='utf-8', index=False, float_format='%.4f')
+
+
 def find_worst_depth_samples(depth_result, num_samples):
+    dfcols = list(depth_result)
     sample_inds = []
-    for colname in ['smooth_loss', 'depth_err']:
-        sorted_result = depth_result[['frame'] + [colname]].sort_values(by=[colname], ascending=False)
+    for colname in ['depth_err']:
+        sorted_result = depth_result[dfcols[:1] + [colname]].sort_values(by=[colname], ascending=False)
         sorted_result = sorted_result.reset_index(drop=True).head(num_samples)
+        sorted_result['srcidx'] = 0
+        sorted_result = sorted_result[['frame', 'srcidx', colname]]
         sample_inds.append(sorted_result)
     return sample_inds
 
 
 def find_worst_pose_samples(pose_result, num_samples):
+    dfcols = list(pose_result)
     sample_inds = []
-    for colname in ['photo_loss', 'trj_err', 'rot_err']:
-        sorted_result = pose_result[['frame', 'source'] + [colname]].sort_values(by=[colname], ascending=False)
+    for colname in ['photo_loss', 'trj_err']:
+        sorted_result = pose_result[dfcols[:2] + [colname]].sort_values(by=[colname], ascending=False)
         sorted_result = sorted_result.reset_index(drop=True).head(num_samples)
         sample_inds.append(sorted_result)
     return sample_inds
 
 
-def save_worst_pose_view(frame, x, model, sample_inds, save_path):
+def save_worst_views(frame, x, model, sample_inds, save_path, scale=1):
     if frame not in sample_inds['frame'].tolist():
         return
 
@@ -154,6 +209,10 @@ def save_worst_pose_view(frame, x, model, sample_inds, save_path):
 
     stacked_image = x['image']
     intrinsic = x['intrinsic']
+    depth_gt = x['depth_gt']
+    pose_gt = x['pose_gt']
+    pose_gt = cp.pose_matr2rvec_batch(pose_gt)
+    depth_gt_ms = uf.multi_scale_depths(depth_gt, [1, 2, 4, 8])
     source_image, target_image = uf.split_into_source_and_target(stacked_image)
 
     predictions = model(x['image'])
@@ -161,39 +220,19 @@ def save_worst_pose_view(frame, x, model, sample_inds, save_path):
     pose_pred = predictions['pose']
     depth_pred_ms = uf.disp_to_depth_tensor(disp_pred_ms)
 
-    synth_target_ms = synthesize_batch_multi_scale(source_image, intrinsic, depth_pred_ms, pose_pred)
+    depth_pred_ms = [depth*scale for depth in depth_pred_ms]
+
+    synth_target_pred_ms = synthesize_batch_multi_scale(source_image, intrinsic, depth_pred_ms, pose_pred)
+
+    synth_target_gt_ms = synthesize_batch_multi_scale(source_image, intrinsic, depth_gt_ms, pose_gt)
 
     for ind in indices:
-        srcidx = sample_inds.loc[ind, 'source']
-        view = uf.make_view(target_image, synth_target_ms[0], depth_pred_ms[0],
-                            source_image, batidx=0, srcidx=srcidx, verbose=False)
+        srcidx = sample_inds.loc[ind, 'srcidx']
+        view = uf.make_view(target_image, synth_target_pred_ms[0], depth_pred_ms[0], source_image,
+                            batidx=0, srcidx=srcidx, verbose=False, synth_gt=synth_target_gt_ms[0])
         filename = op.join(save_path, f"{colname[:3]}_{frame:04d}_{srcidx}.png")
         print("save file:", filename)
         cv2.imwrite(filename, view)
-
-
-def save_worst_depth_view(frame, x, model, sample_inds, save_path):
-    if frame not in sample_inds['frame'].tolist():
-        return
-
-    colname = list(sample_inds)[-1]
-
-    stacked_image = x['image']
-    intrinsic = x['intrinsic']
-    source_image, target_image = uf.split_into_source_and_target(stacked_image)
-
-    predictions = model(x['image'])
-    disp_pred_ms = predictions['disp_ms']
-    pose_pred = predictions['pose']
-    depth_pred_ms = uf.disp_to_depth_tensor(disp_pred_ms)
-
-    synth_target_ms = synthesize_batch_multi_scale(source_image, intrinsic, depth_pred_ms, pose_pred)
-
-    view = uf.make_view(target_image, synth_target_ms[0], depth_pred_ms[0],
-                        source_image, batidx=0, srcidx=0, verbose=False)
-    filename = op.join(save_path, f"{colname[:3]}_{frame:04d}.png")
-    print("save file:", filename)
-    cv2.imwrite(filename, view)
 
 
 if __name__ == "__main__":

--- a/evaluate/evaluate_debug.py
+++ b/evaluate/evaluate_debug.py
@@ -1,0 +1,201 @@
+import os
+import os.path as op
+import numpy as np
+import pandas as pd
+import cv2
+
+import settings
+from config import opts
+from tfrecords.tfrecord_reader import TfrecordGenerator
+import utils.util_funcs as uf
+import utils.convert_pose as cp
+import evaluate.eval_funcs as ef
+from evaluate.evaluate_main import evaluate_depth
+from model.synthesize_batch import synthesize_batch_multi_scale
+from model.loss_and_metric import photometric_loss, smootheness_loss
+from model.model_main import set_configs, create_model, try_load_weights
+
+
+def evaluate_for_debug(data_dir_name, model_name):
+    set_configs(model_name)
+    model = create_model()
+    model = try_load_weights(model, model_name)
+    model.compile(optimizer="sgd", loss="mean_absolute_error")
+
+    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1).get_generator()
+    depth_result = []
+    pose_result = []
+    steps_per_epoch = uf.count_steps(data_dir_name, 1)
+
+    for i, x in enumerate(dataset):
+        uf.print_numeric_progress(i, steps_per_epoch)
+        depth_res, pose_res = evaluate_batch(i, x, model)
+        depth_result.append(depth_res)
+        pose_result.append(pose_res)
+
+    print("")
+    depth_result = save_depth_result_and_get_df(depth_result, model_name)
+    print("depth_result\n", depth_result.head(10))
+    pose_result = save_pose_result_and_get_df(pose_result, model_name)
+    print("pose_result\n", pose_result.head(10))
+
+    depth_sample_inds = find_worst_depth_samples(depth_result, 5)
+    print("depth sample indices\n", depth_sample_inds[0])
+    pose_sample_inds = find_worst_pose_samples(pose_result, 5)
+    print("pose sample indices\n", pose_sample_inds[0])
+
+    pathname = op.join(opts.DATAPATH_EVL, model_name, 'debug_imgs')
+    os.makedirs(pathname, exist_ok=True)
+
+    for i, x in enumerate(dataset):
+        uf.print_numeric_progress(i, steps_per_epoch)
+        for sample_inds in depth_sample_inds:
+            save_worst_depth_view(i, x, model, sample_inds, pathname)
+        for sample_inds in pose_sample_inds:
+            save_worst_pose_view(i, x, model, sample_inds, pathname)
+
+
+def evaluate_batch(index, x, model):
+    num_src = opts.SNIPPET_LEN - 1
+
+    stacked_image = x['image']
+    intrinsic = x['intrinsic']
+    depth_true = x['depth_gt']
+    pose_true_mat = x['pose_gt']
+    source_image, target_image = uf.split_into_source_and_target(stacked_image)
+
+    predictions = model(x['image'])
+    disp_pred_ms = predictions['disp_ms']
+    pose_pred = predictions['pose']
+    depth_pred_ms = uf.disp_to_depth_tensor(disp_pred_ms)
+
+    # evaluate depth from numpy arrays and take only 'abs_rel' metric
+    depth_err = evaluate_depth(depth_pred_ms[0].numpy()[0], depth_true.numpy()[0])
+    depth_err = depth_err[0]
+    smooth_loss = compute_smooth_loss(disp_pred_ms[0], target_image)
+
+    snp_res = [index, smooth_loss, depth_err]
+
+    # evaluate poses
+    pose_pred_mat = cp.pose_rvec2matr_batch(pose_pred)
+    # pose error output: [batch, num_src]
+    trj_err = ef.calc_trajectory_error_tensor(pose_pred_mat, pose_true_mat)
+    rot_err = ef.calc_rotational_error_tensor(pose_pred_mat, pose_true_mat)
+    # compute photometric loss: [batch, num_src]
+    photo_loss = compute_photo_loss(target_image, source_image, intrinsic, depth_pred_ms, pose_pred)
+
+    # src_res: [num_src, -1]
+    src_res = np.stack([np.array([index] * 4), np.arange(num_src), photo_loss.numpy().reshape(-1),
+                        trj_err.numpy().reshape(-1), rot_err.numpy().reshape(-1)], axis=1)
+    return snp_res, src_res
+
+
+def compute_photo_loss(target_true, source_image, intrinsic, depth_pred_ms, pose_pred):
+    # synthesize target image
+    synth_target_ms = synthesize_batch_multi_scale(source_image, intrinsic, depth_pred_ms, pose_pred)
+    losses = []
+    target_pred = synth_target_ms[0]
+    # photometric loss: [batch, num_src]
+    loss = photometric_loss(target_pred, target_true)
+    return loss
+
+
+def compute_smooth_loss(disparity, target_image):
+    # [batch]
+    loss = smootheness_loss(disparity, target_image)
+    # return scalar
+    return loss.numpy()[0]
+
+
+def save_depth_result_and_get_df(depth_result, model_name):
+    depth_result = np.array(depth_result)
+    depth_result = pd.DataFrame(data=depth_result, columns=['frame', 'smooth_loss', 'depth_err'])
+    depth_result['frame'] = depth_result['frame'].astype(int)
+    filename = op.join(opts.DATAPATH_EVL, model_name, 'debug_depth.csv')
+    depth_result.to_csv(filename, encoding='utf-8', index=False, float_format='%.4f')
+    return depth_result
+
+
+def save_pose_result_and_get_df(pose_result, model_name):
+    pose_result = np.concatenate(pose_result, axis=0)
+    columns = ['frame', 'source', 'photo_loss', 'trj_err', 'rot_err']
+    pose_result = pd.DataFrame(data=pose_result, columns=columns)
+    pose_result['frame'] = pose_result['frame'].astype(int)
+    pose_result['source'] = pose_result['source'].astype(int)
+    filename = op.join(opts.DATAPATH_EVL, model_name, 'debug_pose.csv')
+    pose_result.to_csv(filename, encoding='utf-8', index=False, float_format='%.4f')
+    return pose_result
+
+
+def find_worst_depth_samples(depth_result, num_samples):
+    sample_inds = []
+    for colname in ['smooth_loss', 'depth_err']:
+        sorted_result = depth_result[['frame'] + [colname]].sort_values(by=[colname], ascending=False)
+        sorted_result = sorted_result.reset_index(drop=True).head(num_samples)
+        sample_inds.append(sorted_result)
+    return sample_inds
+
+
+def find_worst_pose_samples(pose_result, num_samples):
+    sample_inds = []
+    for colname in ['photo_loss', 'trj_err', 'rot_err']:
+        sorted_result = pose_result[['frame', 'source'] + [colname]].sort_values(by=[colname], ascending=False)
+        sorted_result = sorted_result.reset_index(drop=True).head(num_samples)
+        sample_inds.append(sorted_result)
+    return sample_inds
+
+
+def save_worst_pose_view(frame, x, model, sample_inds, save_path):
+    if frame not in sample_inds['frame'].tolist():
+        return
+
+    colname = list(sample_inds)[-1]
+    indices = sample_inds.loc[sample_inds['frame'] == frame, :].index.tolist()
+
+    stacked_image = x['image']
+    intrinsic = x['intrinsic']
+    source_image, target_image = uf.split_into_source_and_target(stacked_image)
+
+    predictions = model(x['image'])
+    disp_pred_ms = predictions['disp_ms']
+    pose_pred = predictions['pose']
+    depth_pred_ms = uf.disp_to_depth_tensor(disp_pred_ms)
+
+    synth_target_ms = synthesize_batch_multi_scale(source_image, intrinsic, depth_pred_ms, pose_pred)
+
+    for ind in indices:
+        srcidx = sample_inds.loc[ind, 'source']
+        view = uf.make_view(target_image, synth_target_ms[0], depth_pred_ms[0],
+                            source_image, batidx=0, srcidx=srcidx, verbose=False)
+        filename = op.join(save_path, f"{colname[:3]}_{frame:04d}_{srcidx}.png")
+        print("save file:", filename)
+        cv2.imwrite(filename, view)
+
+
+def save_worst_depth_view(frame, x, model, sample_inds, save_path):
+    if frame not in sample_inds['frame'].tolist():
+        return
+
+    colname = list(sample_inds)[-1]
+
+    stacked_image = x['image']
+    intrinsic = x['intrinsic']
+    source_image, target_image = uf.split_into_source_and_target(stacked_image)
+
+    predictions = model(x['image'])
+    disp_pred_ms = predictions['disp_ms']
+    pose_pred = predictions['pose']
+    depth_pred_ms = uf.disp_to_depth_tensor(disp_pred_ms)
+
+    synth_target_ms = synthesize_batch_multi_scale(source_image, intrinsic, depth_pred_ms, pose_pred)
+
+    view = uf.make_view(target_image, synth_target_ms[0], depth_pred_ms[0],
+                        source_image, batidx=0, srcidx=0, verbose=False)
+    filename = op.join(save_path, f"{colname[:3]}_{frame:04d}.png")
+    print("save file:", filename)
+    cv2.imwrite(filename, view)
+
+
+if __name__ == "__main__":
+    np.set_printoptions(precision=3, suppress=True, linewidth=100)
+    evaluate_for_debug('kitti_raw_test', 'vode1')

--- a/evaluate/evaluate_main.py
+++ b/evaluate/evaluate_main.py
@@ -46,11 +46,11 @@ def evaluate(data_dir_name, model_name):
     depth_errors = []
     trajectory_errors = []
     rotational_errors = []
-    uf.print_numeric_progress(None, is_total=True)
-    for i, (x, y) in enumerate(dataset):
+
+    for i, x in enumerate(dataset):
         if i >= total_pose_pred.shape[0]:
             break
-        uf.print_numeric_progress(i)
+        uf.print_numeric_progress(i, 0)
         depth_true = x["depth_gt"].numpy()[0]
         pose_true = x["pose_gt"].numpy()[0]
         depth_pred = total_depth_pred[i]
@@ -62,6 +62,7 @@ def evaluate(data_dir_name, model_name):
         trajectory_errors.append(trj_err)
         rotational_errors.append(rot_err)
 
+    print("")
     depth_errors = np.array(depth_errors)
     trajectory_errors = np.array(trajectory_errors)
     rotational_errors = np.array(rotational_errors)
@@ -126,4 +127,4 @@ def evaluate_pose(pose_pred, pose_true):
 
 if __name__ == "__main__":
     np.set_printoptions(precision=3, suppress=True, linewidth=100)
-    evaluate_by_user_interaction()
+    evaluate('kitti_raw_test', 'vode1')

--- a/model/model_builder.py
+++ b/model/model_builder.py
@@ -1,6 +1,4 @@
 import os.path as op
-import cv2
-import numpy as np
 import tensorflow as tf
 from tensorflow.keras import layers
 

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -1,6 +1,5 @@
 import os
 import os.path as op
-import json
 import tensorflow as tf
 import numpy as np
 import pandas as pd
@@ -60,7 +59,7 @@ def train_by_user_interaction():
 
 
 def train(train_dir_name, val_dir_name, model_name, learning_rate, final_epoch):
-    initial_epoch = read_previous_epoch(model_name)
+    initial_epoch = uf.read_previous_epoch(model_name)
     if final_epoch <= initial_epoch:
         raise TrainException("!! final_epoch <= initial_epoch, no need to train")
 
@@ -70,7 +69,7 @@ def train(train_dir_name, val_dir_name, model_name, learning_rate, final_epoch):
     optimizer = tf.optimizers.Adam(learning_rate=learning_rate)
     dataset_train = TfrecordGenerator(op.join(opts.DATAPATH_TFR, train_dir_name), shuffle=True).get_generator()
     dataset_val = TfrecordGenerator(op.join(opts.DATAPATH_TFR, val_dir_name), shuffle=False).get_generator()
-    steps_per_epoch = count_steps(train_dir_name)
+    steps_per_epoch = uf.count_steps(train_dir_name)
 
     print(f"\n\n========== START TRAINING ON {model_name} ==========")
     for epoch in range(initial_epoch, final_epoch):
@@ -108,40 +107,15 @@ def set_configs(model_name):
             print(e)
 
 
-def try_load_weights(model, model_name):
+def try_load_weights(model, model_name, weight_name='lastes.h5'):
     if model_name:
-        model_file_path = op.join(opts.DATAPATH_CKP, model_name, "latest.h5")
+        model_file_path = op.join(opts.DATAPATH_CKP, model_name, weight_name)
         if op.isfile(model_file_path):
             print("===== load model weights", model_file_path)
             model.load_weights(model_file_path)
         else:
             print("===== train from scratch", model_file_path)
     return model
-
-
-def count_steps(dataset_dir):
-    tfrpath = op.join(opts.DATAPATH_TFR, dataset_dir)
-    with open(op.join(tfrpath, "tfr_config.txt"), "r") as fr:
-        config = json.load(fr)
-    frames = config['length']
-    steps = frames // opts.BATCH_SIZE
-    print(f"[count steps] frames={frames}, steps={steps}")
-    return steps
-
-
-def read_previous_epoch(model_name):
-    filename = op.join(opts.DATAPATH_CKP, model_name, 'history.txt')
-    if op.isfile(filename):
-        history = pd.read_csv(filename, encoding='utf-8', converters={'epoch': lambda c: int(c)})
-        if history.empty:
-            return 0
-        epochs = history['epoch'].tolist()
-        epochs.sort()
-        prev_epoch = epochs[-1]
-        print(f"[read_previous_epoch] start from epoch {prev_epoch + 1}")
-        return prev_epoch + 1
-    else:
-        return 0
 
 
 # Eager training is slow ...
@@ -349,32 +323,28 @@ def save_reconstruction_samples(model, dataset, model_name, epoch):
         cv2.imwrite(filename, view)
 
 
-def predict(test_dir_name, model_name, weights_name):
+def predict(test_dir_name, model_name, weight_name):
     set_configs(model_name)
     model = create_model()
-    model = try_load_weights(model, model_name, weights_name)
+    model = try_load_weights(model, model_name, weight_name)
     model.compile(optimizer="sgd", loss="mean_absolute_error")
 
     dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, test_dir_name)).get_generator()
-    # NOTE! preds = {"disp_ms": ..., "pose": ...} = model(image)
-    #       preds = [disp_s1, disp_s2, disp_s4, disp_s8, pose] = model.predict({"image": ...})
+    # [disp_s1, disp_s2, disp_s4, disp_s8, pose] = model.predict({"image": ...})
     predictions = model.predict(dataset)
     for pred in predictions:
         print(f"prediction shape={pred.shape}")
 
-    pred_disps_ms = predictions[0]
-    pred_pose = predictions[1]
-    print("predicted dispartiy shape:", pred_disps_ms[0].get_shape().as_list())
-    print("predicted dispartiy shape:", pred_disps_ms[2].get_shape().as_list())
-    print("predicted pose shape:", pred_pose.get_shape().as_list())
-    # save_predictions(model_name, pred_disps_ms, pred_pose)
+    pred_disp = predictions[0]
+    pred_pose = predictions[4]
+    save_predictions(model_name, pred_disp, pred_pose)
 
 
-def save_predictions(model_name, pred_disps_ms, pred_pose):
+def save_predictions(model_name, pred_disp, pred_pose):
     pred_dir_path = op.join(opts.DATAPATH_PRD, model_name)
     os.makedirs(pred_dir_path, exist_ok=True)
-    print(f"save depth in {pred_dir_path}, shape={pred_disps_ms[0].shape}")
-    np.save(op.join(pred_dir_path, "depth.npy"), pred_disps_ms)
+    print(f"save depth in {pred_dir_path}, shape={pred_disp[0].shape}")
+    np.save(op.join(pred_dir_path, "depth.npy"), pred_disp)
     print(f"save pose in {pred_dir_path}, shape={pred_pose.shape}")
     np.save(op.join(pred_dir_path, "pose.npy"), pred_pose)
 
@@ -391,7 +361,7 @@ def run_train_default():
 
 
 def run_pred_default():
-    predict(test_dir_name="kitti_raw_test", model_name="vode1", weights_name="latest.h5")
+    predict(test_dir_name="kitti_raw_test", model_name="vode1", weight_name="best.h5")
 
 
 def test_model_output():
@@ -495,5 +465,5 @@ def check_disparity(model_name, test_dir_name):
 if __name__ == "__main__":
     # test_count_steps()
     run_train_default()
-    # run_pred_default()
+    run_pred_default()
     # test_model_output()

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -107,7 +107,7 @@ def set_configs(model_name):
             print(e)
 
 
-def try_load_weights(model, model_name, weight_name='lastes.h5'):
+def try_load_weights(model, model_name, weight_name='latest.h5'):
     if model_name:
         model_file_path = op.join(opts.DATAPATH_CKP, model_name, weight_name)
         if op.isfile(model_file_path):
@@ -350,10 +350,6 @@ def save_predictions(model_name, pred_disp, pred_pose):
 
 
 # ==================== tests ====================
-
-def test_count_steps():
-    steps = count_steps('kitti_raw_train')
-
 
 def run_train_default():
     train(train_dir_name="kitti_raw_test", val_dir_name="kitti_raw_test",

--- a/model/synthesize_batch.py
+++ b/model/synthesize_batch.py
@@ -57,12 +57,13 @@ def reshape_source_images(src_img_stacked, scale):
     :param scale: scale to reduce image size
     :return: reorganized source images [batch, num_src, height/scale, width/scale, 3]
     """
+    batch, height, width, _ = src_img_stacked.get_shape().as_list()
     num_src = (opts.SNIPPET_LEN - 1)
     # resize image
-    scheight, scwidth = (int(opts.IM_HEIGHT // scale), int(opts.IM_WIDTH // scale))
+    scheight, scwidth = (int(height / num_src / scale), int(width / scale))
     scaled_image = tf.image.resize(src_img_stacked, size=(scheight*num_src, scwidth), method="bilinear")
     # reorganize scaled images: (4*height/scale,) -> (4, height/scale)
-    source_images = tf.reshape(scaled_image, shape=(opts.BATCH_SIZE, num_src, scheight, scwidth, 3))
+    source_images = tf.reshape(scaled_image, shape=(batch, num_src, scheight, scwidth, 3))
     return source_images
 
 

--- a/model/synthesize_batch.py
+++ b/model/synthesize_batch.py
@@ -1,5 +1,3 @@
-import os.path as op
-import cv2
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras import layers

--- a/model/test_synthesizing.py
+++ b/model/test_synthesizing.py
@@ -1,7 +1,7 @@
+import os.path as op
 from tensorflow.keras import layers
 import cv2
 
-from config import opts
 from model.synthesize_batch import *
 from tfrecords.tfrecord_reader import TfrecordGenerator
 import utils.convert_pose as cp


### PR DESCRIPTION
## 목적
evaluate_debug.py 작성
각각의 테스트 프레임의 loss와 metric을 계산해서 
어떤 프레임에서 무엇이 잘못되는지 확인하는 것이 목적

## 발견
아직 training을 많이 안해서 target으로 덜 달라붙는 경우도 있지만
의외로 gt pose 자체가 잘못된 경우도 있다.
`kitti_test_raw`에서 350~360 정도의 프레임에서 오차가 크다.
전진했는데 x축(옆방향)으로 더 많이 갔다고 하거나
2 프레임에 z축(전진방향)으로 4~5m 씩 갔다고 나오는 경우가 있다.
(사진을 보면 절대 그정도로 많이 움직이진 않았다.)

odometry 데이터 셋이 아니기 때문에 좌표 값이 부정확할 수도 있다는 생각이 든다.
그래서 예측값으로 reconstruction도 잘되고 photo loss도 낮은데 trajectory error가 
높게 나오는 경우가 종종 있다.
중간의 몇 20프레임 정도 제외하면 나머지는 대부분 gt값이 잘 맞는것 같다.

## 출력
- debug_depth.csv: 타겟 프레임별로 predicted depth의 error와 smootheness loss 저장
- debug_pose.csv: 소스 프레임별로 photometric loss, trajectory error, rotation error 저장
- trajectory.csv: 소스 프레임별로 gt trajectory, pred trajectory 저장
- debug_imgs(디렉토리): loss와 metric 별로 가장 성능이 안좋은 프레임들을 모아서 inspection view 이미지로 저장
    1. target image
    2. reconstructed target from gt
    3. reconstructed target from pred
    4. source image
    5. predicted target depth
