### PR TITLE
Create odometry validation split

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -3,14 +3,7 @@ import os.path as op
 
 class VodeOptions:
     def __init__(self):
-        self.KITTI_RAW_PATH = "/media/ian/IanPrivatePP/Datasets/kitti_raw_data"
-        self.KITTI_ODOM_PATH = "/media/ian/IanPrivatePP/Datasets/kitti_odometry"
-        if not op.isdir(self.KITTI_RAW_PATH):
-            print("===== WARNING: kitti raw data path does NOT exists")
-        if not op.isdir(self.KITTI_ODOM_PATH):
-            print("===== WARNING: kitti odom data path does NOT exists")
-
-        self.DATASET = "kitti_raw"
+        self.DATASET = None
         self.SNIPPET_LEN = 5
         self.IM_WIDTH = 416
         self.IM_HEIGHT = 128
@@ -30,13 +23,23 @@ class VodeOptions:
         self.DATAPATH_PRD = op.join(self.DATAPATH, "prediction")
         self.DATAPATH_EVL = op.join(self.DATAPATH, "evaluation")
 
+
+class KittiOptions(VodeOptions):
+    def __init__(self):
+        super().__init__()
+        self.DATASET = "kitti_raw"
+        self.KITTI_RAW_PATH = "/media/ian/IanPrivatePP/Datasets/kitti_raw_data"
+        self.KITTI_ODOM_PATH = "/media/ian/IanPrivatePP/Datasets/kitti_odometry"
+        if not op.isdir(self.KITTI_RAW_PATH):
+            print("===== WARNING: kitti raw data path does NOT exists")
+        if not op.isdir(self.KITTI_ODOM_PATH):
+            print("===== WARNING: kitti odom data path does NOT exists")
+
     def get_dataset_path(self, dataset=None):
         if dataset is None:
-            if self.DATASET == "kitti_raw":
-                return self.KITTI_RAW_PATH
-            elif self.DATASET == "kitti_odom":
-                return self.KITTI_ODOM_PATH
-        elif dataset == "kitti_raw":
+            dataset = self.DATASET
+
+        if dataset == "kitti_raw":
             return self.KITTI_RAW_PATH
         elif dataset == "kitti_odom":
             return self.KITTI_ODOM_PATH
@@ -44,4 +47,4 @@ class VodeOptions:
             raise ValueError()
 
 
-opts = VodeOptions()
+opts = KittiOptions()

--- a/evaluate/evaluate_debug.py
+++ b/evaluate/evaluate_debug.py
@@ -17,6 +17,23 @@ from model.model_main import set_configs, create_model, try_load_weights
 
 
 def evaluate_for_debug(data_dir_name, model_name):
+    """
+    function to check if learning process is going right
+    to evaluate current model, save losses and error metrics to csv files and save debugging images
+    - debug_depth.csv: 타겟 프레임별로 predicted depth의 error와 smootheness loss 저장
+    - debug_pose.csv: 소스 프레임별로 photometric loss, trajectory error, rotation error 저장
+    - trajectory.csv: 소스 프레임별로 gt trajectory, pred trajectory 저장
+    - debug_imgs(directory): loss와 metric 별로 가장 성능이 안좋은 프레임들을 모아서 inspection view 이미지로 저장
+        1) target image
+        2) reconstructed target from gt
+        3) reconstructed target from pred
+        4) source image
+        5) predicted target depth
+    """
+    if not uf.check_tfrecord_including(op.join(opts.DATAPATH_TFR, data_dir_name), ["pose_gt", "depth_gt"]):
+        print("Evaluation is NOT possible without pose_gt and depth_gt")
+        return
+
     set_configs(model_name)
     model = create_model()
     model = try_load_weights(model, model_name)
@@ -148,6 +165,7 @@ def compute_depth_error(depth_pred, depth_true):
     metrics = ef.compute_depth_metrics(depth_true[mask], depth_pred[mask])
     # return only abs rel
     return metrics[0], scaler
+
 
 def save_depth_result_and_get_df(depth_result, model_name):
     depth_result = np.array(depth_result)

--- a/model/loss_and_metric.py
+++ b/model/loss_and_metric.py
@@ -168,6 +168,8 @@ import numpy as np
 import cv2
 from tfrecords.tfrecord_reader import TfrecordGenerator
 
+WAIT_KEY = 200
+
 
 def test_photometric_loss_quality():
     """
@@ -210,7 +212,7 @@ def test_photometric_loss_quality():
             view = np.concatenate([target, srcimg0, recon0, srcimg3, recon3], axis=0)
             print(f"1/{scale} scale, photo loss:", tf.reduce_sum(loss, axis=1))
             cv2.imshow("photo loss", view)
-            cv2.waitKey()
+            cv2.waitKey(WAIT_KEY)
 
         losses = tf.stack(losses, axis=2)       # [batch, num_src, num_scales]
         print("all photometric loss:", tf.reduce_sum(losses, axis=1))
@@ -265,7 +267,7 @@ def test_photometric_loss_quantity():
         target = uf.to_uint8_image(target_image).numpy()[0]
         view = np.concatenate([target, recon_image_right, recon_image_wrong], axis=0)
         cv2.imshow("pose corruption", view)
-        cv2.waitKey()
+        cv2.waitKey(WAIT_KEY)
         if i > 3:
             break
 
@@ -341,7 +343,7 @@ def test_smootheness_loss_quantity():
 
         view = np.concatenate([depth_gt_right[0], depth_gt_wrong[0]], axis=0)
         cv2.imshow("target image corruption", view)
-        cv2.waitKey()
+        cv2.waitKey(WAIT_KEY)
         if i > 3:
             break
 

--- a/model/test_synthesizing.py
+++ b/model/test_synthesizing.py
@@ -7,6 +7,8 @@ from tfrecords.tfrecord_reader import TfrecordGenerator
 import utils.convert_pose as cp
 import utils.util_funcs as uf
 
+WAIT_KEY = 200
+
 
 def test_synthesize_batch_multi_scale():
     """
@@ -39,7 +41,7 @@ def test_synthesize_batch_multi_scale():
         view = np.concatenate([source_image, target_image, recon_img0, recon_img1], axis=0)
         print("Check if all the images are the same")
         cv2.imshow("source, target, and reconstructed", view)
-        cv2.waitKey()
+        cv2.waitKey(WAIT_KEY)
         if i >= 3:
             break
 
@@ -52,8 +54,9 @@ def test_synthesize_batch_view():
     gt depth와 gt pose를 입력했을 때 스케일 별로 복원되는 이미지를 정성적으로 확인
     실제 target image와 복원된 "single" scale target image를 눈으로 비교
     """
-    print("===== start test_synthesize_batch_view")
     dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_generator()
+
+    print("\n===== start test_synthesize_batch_view")
     scale_idx = 1
 
     for i, features in enumerate(dataset):
@@ -89,7 +92,7 @@ def test_synthesize_batch_view():
         recon_image = cv2.resize(recon_image, (width, height*4), interpolation=cv2.INTER_NEAREST)
         view = np.concatenate([target_image, recon_image], axis=0)
         cv2.imshow("synthesize_batch", view)
-        cv2.waitKey()
+        cv2.waitKey(WAIT_KEY)
         if i >= 3:
             break
 
@@ -123,7 +126,7 @@ def test_reshape_source_images():
 
     view = np.concatenate([scaled_image, reshaped_image[0, 1]], axis=0)
     cv2.imshow("original and reshaped", view)
-    cv2.waitKey()
+    cv2.waitKey(WAIT_KEY)
     print("!!! test_reshape_source_images passed")
     cv2.destroyAllWindows()
 
@@ -284,11 +287,11 @@ def test_all():
     test_synthesize_batch_multi_scale()
     test_synthesize_batch_view()
     test_reshape_source_images()
-    # test_scale_intrinsic()
-    # test_pixel2cam()
-    # test_transform_to_source()
-    # test_pixel_weighting()
-    # test_reconstruct_bilinear_interp()
+    test_scale_intrinsic()
+    test_pixel2cam()
+    test_transform_to_source()
+    test_pixel_weighting()
+    test_reconstruct_bilinear_interp()
 
 
 if __name__ == "__main__":

--- a/prepare_data/kitti_loader.py
+++ b/prepare_data/kitti_loader.py
@@ -5,7 +5,6 @@ import settings
 from config import opts
 import prepare_data.kitti_util as ku
 import utils.convert_pose as cp
-from utils.util_class import NoDataException
 
 
 class KittiDataLoader:

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import settings
 from config import opts
-from kitti_loader import KittiDataLoader
+from prepare_data.kitti_loader import KittiDataLoader
 from utils.util_funcs import print_progress_status
 
 
@@ -14,6 +14,7 @@ def prepare_input_data():
         for split in ["train", "test"]:
             loader = KittiDataLoader(opts.get_dataset_path(dataset), dataset, split)
             prepare_and_save_snippets(loader, dataset, split)
+    # TODO: validatation set 따로 만들기: 일부 복사하거나 링크만 걸거나
 
 
 def prepare_and_save_snippets(loader, dataset, split):
@@ -34,8 +35,10 @@ def prepare_and_save_snippets(loader, dataset, split):
             continue
 
         os.makedirs(snippet_path, exist_ok=True)
-        os.makedirs(pose_path, exist_ok=True)
-        os.makedirs(depth_path, exist_ok=True)
+        if loader.kitti_reader.pose_avail:
+            os.makedirs(pose_path, exist_ok=True)
+        if loader.kitti_reader.depth_avail:
+            os.makedirs(depth_path, exist_ok=True)
 
         num_frames = len(frame_indices)
         for k, index in enumerate(frame_indices):
@@ -43,16 +46,16 @@ def prepare_and_save_snippets(loader, dataset, split):
             index = snippet["index"]
             frames = snippet["frames"]
             filename = op.join(snippet_path, f"{index:06d}.png")
-            cv2.imwrite(filename, frames,)
+            cv2.imwrite(filename, frames)
 
-            poses = snippet["gt_poses"]
-            if poses is not None:
+            if "gt_poses" in snippet:
+                poses = snippet["gt_poses"]
                 filename = op.join(pose_path, f"{index:06d}.txt")
                 np.savetxt(filename, poses, fmt="%3.5f")
 
-            depth = snippet["gt_depth"]
             mean_depth = 0
-            if depth is not None:
+            if "gt_depth" in snippet:
+                depth = snippet["gt_depth"]
                 filename = op.join(depth_path, f"{index:06d}.txt")
                 np.savetxt(filename, depth, fmt="%3.5f")
                 mean_depth = np.mean(depth)
@@ -83,6 +86,14 @@ def get_destination_paths(dstpath, dataset, drive):
     return drive_path, pose_path, depth_path
 
 
+def prepare_single_dataset():
+    dataset = "kitti_odom"
+    split = "train"
+    loader = KittiDataLoader(opts.get_dataset_path(dataset), dataset, split)
+    prepare_and_save_snippets(loader, dataset, split)
+
+
 if __name__ == "__main__":
     np.set_printoptions(precision=3, suppress=True)
-    prepare_input_data()
+    # prepare_input_data()
+    prepare_single_dataset()

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -2,6 +2,7 @@ import os
 import os.path as op
 import cv2
 import numpy as np
+import shutil
 
 import settings
 from config import opts
@@ -14,7 +15,7 @@ def prepare_input_data():
         for split in ["train", "test"]:
             loader = KittiDataLoader(opts.get_dataset_path(dataset), dataset, split)
             prepare_and_save_snippets(loader, dataset, split)
-    # TODO: validatation set 따로 만들기: 일부 복사하거나 링크만 걸거나
+        create_validation_set(dataset)
 
 
 def prepare_and_save_snippets(loader, dataset, split):
@@ -86,6 +87,22 @@ def get_destination_paths(dstpath, dataset, drive):
     return drive_path, pose_path, depth_path
 
 
+def create_validation_set(dataset):
+    srcpath = op.join(opts.DATAPATH_SRC, f"{dataset}_test")
+    dstpath = op.join(opts.DATAPATH_SRC, f"{dataset}_val")
+
+    if dataset == "kitti_raw":
+        if os.path.exists(dstpath):
+            os.remove(dstpath)
+        os.symlink(srcpath, dstpath)
+    elif dataset == "kitti_odom":
+        os.makedirs(dstpath, exist_ok=True)
+        for drive in ["09", "10"]:
+            shutil.copytree(os.path.join(srcpath, drive), os.path.join(dstpath, drive))
+
+    print(f"\n### create validation split for {dataset}")
+
+
 def prepare_single_dataset():
     dataset = "kitti_odom"
     split = "train"
@@ -95,5 +112,5 @@ def prepare_single_dataset():
 
 if __name__ == "__main__":
     np.set_printoptions(precision=3, suppress=True)
-    # prepare_input_data()
-    prepare_single_dataset()
+    prepare_input_data()
+    # prepare_single_dataset()

--- a/tfrecords/tfrecord_reader.py
+++ b/tfrecords/tfrecord_reader.py
@@ -81,19 +81,13 @@ class TfrecordGenerator:
             if not isinstance(feat_conf, dict):
                 continue
 
-            if feat_conf["decode_type"] is None:
-                decoded[key] = parsed[key]
-            else:
-                decoded[key] = tf.io.decode_raw(parsed[key], feat_conf["decode_type"])
-
+            decoded[key] = tf.io.decode_raw(parsed[key], feat_conf["decode_type"])
             if feat_conf["shape"] is not None:
                 decoded[key] = tf.reshape(decoded[key], shape=feat_conf["shape"])
 
-        # raw uint8 type may saturate during bilinear interpolation
+        # raw uint8 type may saturate during bilinear interpolation -> float (-1 ~ 1)
         decoded["image"] = uf.to_float_image(decoded["image"])
-        features = {"image": decoded["image"], "pose_gt": decoded["pose"],
-                    "depth_gt": decoded["depth"], "intrinsic": decoded["intrinsic"]}
-        return features
+        return decoded
 
     def dataset_process(self, dataset):
         if self.shuffle:

--- a/tfrecords/tfrecord_writer.py
+++ b/tfrecords/tfrecord_writer.py
@@ -141,7 +141,7 @@ def image_reader(filename):
 def pose_reader(filename):
     """
     quaternion based pose to transformation matrix omitting target pose (identity)
-    order: [src0 src1 tgt src2 src3] -> [src1 src2 src3 src4]
+    order: [src0 src1 tgt src2 src3] -> [src0 src1 src2 src3]
     shape: [5, 7] -> [4, 4, 4]
     """
     poses = np.loadtxt(filename)

--- a/tfrecords/tfrecord_writer.py
+++ b/tfrecords/tfrecord_writer.py
@@ -55,9 +55,9 @@ class TfrecordMaker:
                    "intrinsic": df.NpyFeeder(intrin_files, txt_reader),
                    }
         if self.depth_avail:
-            feeders["depth"] = df.NpyFeeder(depth_files, depth_reader)
+            feeders["depth_gt"] = df.NpyFeeder(depth_files, depth_reader)
         if self.pose_avail:
-            feeders["pose"] = df.NpyFeeder(pose_files, pose_reader)
+            feeders["pose_gt"] = df.NpyFeeder(pose_files, pose_reader)
 
         return feeders
 

--- a/utils/convert_pose.py
+++ b/utils/convert_pose.py
@@ -5,6 +5,7 @@ from utils.decorators import ShapeCheck
 
 
 def pose_quat2matr(pose):
+    assert pose.shape[0] == 7
     t = np.expand_dims(pose[:3], axis=1)
     q = pose[3:]
     norm = np.linalg.norm(q)

--- a/utils/util_class.py
+++ b/utils/util_class.py
@@ -2,3 +2,8 @@
 class TrainException(Exception):
     def __init__(self, msg):
         super().__init__(msg)
+
+
+class NoDataException(Exception):
+    def __init__(self, msg):
+        super().__init__(msg)

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -111,6 +111,17 @@ def count_steps(dataset_dir, batch_size=opts.BATCH_SIZE):
     return steps
 
 
+def check_tfrecord_including(dataset_dir, key_list):
+    tfrpath = op.join(opts.DATAPATH_TFR, dataset_dir)
+    with open(op.join(tfrpath, "tfr_config.txt"), "r") as fr:
+        config = json.load(fr)
+
+    for key in key_list:
+        if key not in config:
+            return False
+    return True
+
+
 def read_previous_epoch(model_name):
     filename = op.join(opts.DATAPATH_CKP, model_name, 'history.txt')
     if op.isfile(filename):


### PR DESCRIPTION

## config.py
VodeOptions()에 기본 옵션 다 넣고 KittiOption()에서 상속 받아 kitti 관련 경로 변수 추가

## prepare_data
- pykitti.raw() 나 pykitti.odometry() 를 Kitti*Utils의 멤버 변수로 포함
- pose나 depth 데이터가 없으면 아예 pose, depth 폴더를 만들지 않음
- kitti_raw 데이터셋은 만들어진 'test' 데이터셋 디렉토리의 symlink로 'val' 데이터셋 만듦
- kitti_odom 데이터셋은 만들어진 'test' 데이터셋의 09, 10 drive만 복사해서 'val' 데이터셋 만듦

## tfrecord
- srcdata에 pose, depth 없으면 feature dict에 아예 pose, depth를 않고 tfrecords로 저장
- tfrecords로 저장할 때부터 pose, depth 데이터에 대한 key를 'pose_gt', 'depth_gt'로 변경
- tfrecords를 읽을 때도 pose, depth 없으면 없는대로 데이터 출력

## model, evaluation or test functions
tfrecord에서 나온 feature에 'pose_gt'나 'depth_gt'가 없어도 에러 내지 않도록 수정
