### PR TITLE
Make stereo data to tfrecords

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -5,6 +5,7 @@ class VodeOptions:
     """
     data options
     """
+    STEREO = True
     SNIPPET_LEN = 5
     IM_WIDTH = 384
     IM_HEIGHT = 128
@@ -18,13 +19,13 @@ class VodeOptions:
     EPOCHS = 51
     LEARNING_RATE = 0.0002
     ENABLE_SHAPE_DECOR = False
-    CKPT_NAME = "vode_ssim"
+    CKPT_NAME = "vode1"
     LOG_LOSS = False
 
     """
     path options
     """
-    DATAPATH = "/media/ian/IanPrivatePP/Datasets/vode_data_384"
+    DATAPATH = "/media/ian/IanPrivatePP/Datasets/vode_data_384_stereo"
     assert(op.isdir(DATAPATH))
     DATAPATH_SRC = op.join(DATAPATH, "srcdata")
     DATAPATH_TFR = op.join(DATAPATH, "tfrecords")

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -41,14 +41,14 @@ def train():
     if opts.EPOCHS <= initial_epoch:
         raise TrainException("!! final_epoch <= initial_epoch, no need to train")
 
-    set_configs(opts.CKPT_NAME)
+    set_configs()
     pretrained_weight = (initial_epoch == 0) and opts.PRETRAINED_WEIGHT
     model = ModelFactory(pretrained_weight=pretrained_weight).get_model()
     model = try_load_weights(model, opts.CKPT_NAME)
 
-    # TODO WARNING! using "val" split for training dataset is just to check training process
-    dataset_train, train_steps = get_dataset(opts.DATASET, "val")
-    dataset_val, val_steps = get_dataset(opts.DATASET, "val")
+    # TODO WARNING! using "test" split for training dataset is just to check training process
+    dataset_train, train_steps = get_dataset(opts.DATASET, "test")
+    dataset_val, val_steps = get_dataset(opts.DATASET, "test")
     optimizer = optimizer_factory("adam_constant", opts.LEARNING_RATE, initial_epoch)
 
     print(f"\n\n========== START TRAINING ON {opts.CKPT_NAME} ==========")

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -66,7 +66,7 @@ def train():
         if epoch % 10 == 0:
             log.save_reconstruction_samples(model, dataset_val, epoch)
             log.save_loss_scales(model, dataset_val, val_steps)
-        save_model(model, opts.CKPT_NAME, result_val[1])
+        save_model(model, result_val[0])
         log.save_log(epoch, result_train, result_val)
 
 

--- a/prepare_data/kitti_depth_generator.py
+++ b/prepare_data/kitti_depth_generator.py
@@ -5,50 +5,39 @@ import os
 from collections import Counter
 
 
-def generate_depth_map(velo_data, calib_dir, orig_shape, target_shape, right=False):
-    cam = '03' if right else '02'
-    # load calibration files
-    cam2cam = read_calib_file(os.path.join(calib_dir, 'calib_cam_to_cam.txt'))
-    velo2cam = read_calib_file(os.path.join(calib_dir, 'calib_velo_to_cam.txt'))
-    velo2cam = np.hstack((velo2cam['R'].reshape(3, 3), velo2cam['T'][..., np.newaxis]))
-    velo2cam = np.vstack((velo2cam, np.array([0, 0, 0, 1.0])))
-
-    # compute projection matrix velodyne->image plane
-    R_cam2rect = np.eye(4)
-    R_cam2rect[:3, :3] = cam2cam['R_rect_00'].reshape(3, 3)
-    P_rect = cam2cam['P_rect_' + cam].reshape(3, 4)
-    P_velo2im = np.dot(np.dot(P_rect, R_cam2rect), velo2cam)
-
-    # load velodyne points and remove all behind image plane (approximation)
-    # each row of the velodyne data is forward, left, up, reflectance
-    velo_data = velo_data[velo_data[:, 0] >= 0, :]
+def generate_depth_map(velo_data, T_cam_velo, K_cam, orig_shape, target_shape):
+    # remove all velodyne points behind image plane (approximation)
+    # each row of the velodyne data is forward, left, up, reflectance(0)
+    velo_data = velo_data[velo_data[:, 0] >= 0, :].T    # (N, 4) => (4, N)
+    velo_data[3, :] = 1
+    velo_in_camera = np.dot(T_cam_velo, velo_data)      # => (3, N)
 
     """ CAUTION!
     orig_shape, target_shape: (height, width) 
-    velo_pts_im[i, :] = (x, y)
+    velo_data[i, :] = (x, y, z)
     """
-    orig_height, orig_width = orig_shape
     targ_height, targ_width = target_shape
+    orig_height, orig_width = orig_shape
+    # rescale intrinsic parameters to target image shape
+    K_prj = K_cam.copy()
+    K_prj[0, :] *= (targ_width / orig_width)    # fx, cx *= target_width / orig_width
+    K_prj[1, :] *= (targ_height / orig_height)  # fy, cy *= target_height / orig_height
 
     # project the points to the camera
-    velo_pts_im = np.dot(P_velo2im, velo_data.T).T
-    velo_pts_im[:, :2] = velo_pts_im[:, :2] / velo_pts_im[:, 2][..., np.newaxis]
-
-    # rescale pixel points to target size
-    velo_pts_im[:, 0] = velo_pts_im[:, 0] / orig_width * targ_width
-    velo_pts_im[:, 1] = velo_pts_im[:, 1] / orig_height * targ_height
+    velo_pts_im = np.dot(K_prj, velo_in_camera[:3])         # => (3, N)
+    velo_pts_im[:2] = velo_pts_im[:2] / velo_pts_im[2:3]    # (u, v, z)
 
     # check if in bounds
     # use minus 1 to get the exact same value as KITTI matlab code
-    velo_pts_im[:, 0] = np.round(velo_pts_im[:, 0]) - 1
-    velo_pts_im[:, 1] = np.round(velo_pts_im[:, 1]) - 1
-    val_inds = (velo_pts_im[:, 0] >= 0) & (velo_pts_im[:, 1] >= 0)
-    val_inds = val_inds & (velo_pts_im[:, 0] < targ_width) & (velo_pts_im[:, 1] < targ_height)
-    velo_pts_im = velo_pts_im[val_inds, :]
+    velo_pts_im[0] = np.round(velo_pts_im[0]) - 1
+    velo_pts_im[1] = np.round(velo_pts_im[1]) - 1
+    valid_x = (velo_pts_im[0] >= 0) & (velo_pts_im[0] < targ_width)
+    valid_y = (velo_pts_im[1] >= 0) & (velo_pts_im[1] < targ_height)
+    velo_pts_im = velo_pts_im[:, valid_x & valid_y]
 
     # project to image
     depth = np.zeros(target_shape)
-    depth[velo_pts_im[:, 1].astype(np.int), velo_pts_im[:, 0].astype(np.int)] = velo_pts_im[:, 2]
+    depth[velo_pts_im[1].astype(np.int), velo_pts_im[0].astype(np.int)] = velo_pts_im[2]
 
     # find the duplicate points and choose the closest depth
     inds = sub2ind(depth.shape, velo_pts_im[:, 1], velo_pts_im[:, 0])

--- a/prepare_data/kitti_depth_generator.py
+++ b/prepare_data/kitti_depth_generator.py
@@ -1,7 +1,4 @@
-# Mostly based on the code written by Clement Godard: 
-# https://github.com/mrharicot/monodepth/blob/master/utils/evaluation_utils.py
 import numpy as np
-import os
 from collections import Counter
 
 

--- a/prepare_data/kitti_loader.py
+++ b/prepare_data/kitti_loader.py
@@ -138,6 +138,8 @@ class KittiDataLoaderStereo(KittiDataLoader):
             example["pose_gt"] = self.load_snippet_poses_stereo(indices, snippet_len)
         if self.kitti_reader.depth_avail:
             example["depth_gt"] = self.load_frame_depth_stereo(index, self.drive_path, raw_img_shape)
+        if self.kitti_reader.stereo:
+            example["stereo_T_LR"] = self.kitti_reader.get_stereo_extrinsic()
         return example
 
     def load_snippet_frames_stereo(self, frame_indices):

--- a/prepare_data/kitti_loader.py
+++ b/prepare_data/kitti_loader.py
@@ -193,7 +193,7 @@ def test_kitti_loader():
             print("this drive is EMPTY")
             continue
 
-        for index, i in enumerate(frame_indices):
+        for index in frame_indices:
             example = loader.example_generator(index, opts.SNIPPET_LEN)
             index = example["index"]
             frames = example["image"]

--- a/prepare_data/kitti_loader.py
+++ b/prepare_data/kitti_loader.py
@@ -5,45 +5,58 @@ import settings
 from config import opts, get_raw_data_path
 import prepare_data.kitti_util as ku
 import utils.convert_pose as cp
+from utils.util_class import WrongInputException
+
+"""
+KittiDataLoader: generates training example, main function is snippet_generator()
+KittiReader: reads data from files
+"""
+
+
+def kitti_loader_factory(base_path, dataset, split):
+    stereo = opts.STEREO
+    if dataset == "kitti_raw" and split == "train":
+        data_reader = ku.KittiRawTrainUtil(stereo)
+    elif dataset == "kitti_raw" and split == "test":
+        data_reader = ku.KittiRawTestUtil(stereo)
+    elif dataset == "kitti_odom" and split == "train":
+        data_reader = ku.KittiOdomTrainReader(stereo)
+    elif dataset == "kitti_odom" and split == "test":
+        data_reader = ku.KittiOdomTestReader(stereo)
+    else:
+        raise WrongInputException(f"Wrong dataset and split: {dataset}, {split}")
+
+    if stereo:
+        return KittiDataLoaderStereo(base_path, split, data_reader)
+    else:
+        return KittiDataLoader(base_path, split, data_reader)
 
 
 class KittiDataLoader:
-    def __init__(self, base_path, dataset, split):
+    def __init__(self, base_path, split, reader):
         self.base_path = base_path
-        self.kitti_reader = self.kitti_reader_factory(dataset, split)
+        self.kitti_reader = reader
         self.drive_list = self.kitti_reader.list_drives(split, base_path)
         self.drive_path = ""
         self.frame_inds = []
 
-    def kitti_reader_factory(self, dataset, split):
-        if dataset == "kitti_raw" and split == "train":
-            return ku.KittiRawTrainUtil()
-        elif dataset == "kitti_raw" and split == "test":
-            return ku.KittiRawTestUtil()
-        elif dataset == "kitti_odom" and split == "train":
-            return ku.KittiOdomTrainUtil()
-        elif dataset == "kitti_odom" and split == "test":
-            return ku.KittiOdomTestUtil()
-        else:
-            raise ValueError()
-
     def load_drive(self, drive, snippet_len):
         self.kitti_reader.create_drive_loader(self.base_path, drive)
-        self.drive_path = self.kitti_reader.get_drive_path(self.base_path, drive)
-        self.frame_inds = self.kitti_reader.frame_indices(self.drive_path, snippet_len)
+        self.drive_path = self.kitti_reader.make_drive_path(self.base_path, drive)
+        self.frame_inds = self.kitti_reader.find_frame_indices(self.drive_path, snippet_len)
         if self.frame_inds.size > 1:
             print(f"frame_indices: {self.frame_inds[0]} ~ {self.frame_inds[-1]}")
         return self.frame_inds
 
-    def snippet_generator(self, index, snippet_len):
+    def example_generator(self, index, snippet_len):
         example = dict()
         example["index"] = index
-        example["frames"], raw_img_shape = self.load_snippet_frames(index, snippet_len)
+        example["image"], raw_img_shape = self.load_snippet_frames(index, snippet_len)
         example["intrinsic"] = self.load_intrinsic(raw_img_shape)
         if self.kitti_reader.pose_avail:
-            example["gt_poses"] = self.load_snippet_poses(index, snippet_len)
+            example["pose_gt"] = self.load_snippet_poses(index, snippet_len)
         if self.kitti_reader.depth_avail:
-            example["gt_depth"] = self.load_frame_depth(index, self.drive_path, raw_img_shape)
+            example["depth_gt"] = self.load_frame_depth(index, self.drive_path, raw_img_shape)
         return example
 
     def load_snippet_frames(self, frame_idx, snippet_len):
@@ -52,7 +65,6 @@ class KittiDataLoader:
         raw_img_shape = ()
         for ind in range(frame_idx-halflen, frame_idx+halflen+1):
             frame = self.kitti_reader.get_image(ind)
-            frame = np.array(frame[0])
             raw_img_shape = frame.shape[:2]
             frame = cv2.resize(frame, dsize=(opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_LINEAR)
             frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
@@ -88,8 +100,7 @@ class KittiDataLoader:
 
     def load_frame_depth(self, frame_idx, drive_path, raw_img_shape):
         dst_shape = (opts.IM_HEIGHT, opts.IM_WIDTH)
-        #########
-        depth_map = self.kitti_reader.load_depth_map(frame_idx, drive_path, raw_img_shape, dst_shape)
+        depth_map = self.kitti_reader.get_depth_map(frame_idx, drive_path, raw_img_shape, dst_shape)
         return depth_map
 
     def load_intrinsic(self, raw_img_shape):
@@ -102,6 +113,78 @@ class KittiDataLoader:
         out[1, 1] *= sy
         out[1, 2] *= sy
         return out
+
+
+class KittiDataLoaderStereo(KittiDataLoader):
+    def __init__(self, base_path, split, reader):
+        super().__init__(base_path, split, reader)
+
+    def load_drive(self, drive, snippet_len):
+        self.kitti_reader.create_drive_loader(self.base_path, drive)
+        self.drive_path = self.kitti_reader.make_drive_path(self.base_path, drive)
+        self.frame_inds = self.kitti_reader.find_frame_indices(self.drive_path, snippet_len)
+        if self.frame_inds.size > 1:
+            print(f"frame_indices: {self.frame_inds[0]} ~ {self.frame_inds[-1]}")
+        return self.frame_inds
+
+    def example_generator(self, index, snippet_len):
+        example = dict()
+        example["index"] = index
+        example["image"], raw_img_shape = self.load_snippet_frames_stereo(index, snippet_len)
+        example["intrinsic"] = self.load_intrinsic_stereo(raw_img_shape)
+        if self.kitti_reader.pose_avail:
+            example["pose_gt"] = self.load_snippet_poses_stereo(index, snippet_len)
+        if self.kitti_reader.depth_avail:
+            example["depth_gt"] = self.load_frame_depth_stereo(index, self.drive_path, raw_img_shape)
+        return example
+
+    def load_snippet_frames_stereo(self, frame_idx, snippet_len):
+        halflen = snippet_len//2
+        frames = []
+        raw_img_shape = ()
+        for ind in range(frame_idx-halflen, frame_idx+halflen+1):
+            img_lef, img_rig = self.kitti_reader.get_image(ind)
+            raw_img_shape = img_lef.shape[:2]
+            img_lef = cv2.resize(img_lef, (opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_LINEAR)
+            img_lef = cv2.cvtColor(img_lef, cv2.COLOR_RGB2BGR)
+            img_rig = cv2.resize(img_rig, (opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_LINEAR)
+            img_rig = cv2.cvtColor(img_rig, cv2.COLOR_RGB2BGR)
+            frame = np.concatenate([img_lef, img_rig], axis=1)
+            frames.append(frame)
+
+        frames = np.concatenate(frames, axis=0)
+        return frames, raw_img_shape
+
+    def load_intrinsic_stereo(self, raw_img_shape):
+        intrin_lef, intrin_rig = self.kitti_reader.get_intrinsic()
+        intrinsic = np.concatenate([intrin_lef, intrin_rig], axis=1)
+        sx = opts.IM_WIDTH / raw_img_shape[1]
+        sy = opts.IM_HEIGHT / raw_img_shape[0]
+        intrinsic[0, :] = intrinsic[0, :] * sx
+        intrinsic[1, :] = intrinsic[1, :] * sy
+        return intrinsic
+
+    def load_snippet_poses_stereo(self, frame_idx, snippet_len):
+        halflen = snippet_len//2
+        pose_seq_lef = []
+        pose_seq_rig = []
+        for ind in range(frame_idx-halflen, frame_idx+halflen+1):
+            pose_lef, pose_rig = self.kitti_reader.get_quat_pose(ind)
+            pose_seq_lef.append(pose_lef)
+            pose_seq_rig.append(pose_rig)
+
+        pose_seq_lef = np.stack(pose_seq_lef, axis=0)
+        pose_seq_rig = np.stack(pose_seq_rig, axis=0)
+        pose_seq_lef = self.to_local_pose(pose_seq_lef, halflen)
+        pose_seq_rig = self.to_local_pose(pose_seq_rig, halflen)
+        poses = np.concatenate([pose_seq_lef, pose_seq_rig], axis=1)
+        return poses
+
+    def load_frame_depth_stereo(self, frame_idx, drive_path, raw_img_shape):
+        dst_shape = (opts.IM_HEIGHT, opts.IM_WIDTH)
+        depth_lef, depth_rig = self.kitti_reader.get_depth_map(frame_idx, drive_path, raw_img_shape, dst_shape)
+        depth = np.concatenate([depth_lef, depth_rig], axis=1)
+        return depth
 
 
 def test():
@@ -118,9 +201,9 @@ def test():
         for index, i in enumerate(frame_indices):
             snippet = loader.snippet_generator(index, opts.SNIPPET_LEN)
             index = snippet["index"]
-            frames = snippet["frames"]
-            poses = snippet["gt_poses"]
-            depths = snippet["gt_depth"]
+            frames = snippet["image"]
+            poses = snippet["pose_gt"]
+            depths = snippet["depth_gt"]
             intrinsic = snippet["intrinsic"]
             print(f"frame {index}: concatenated image shape={frames.shape}, pose shape={poses.shape}")
             print("pose", poses[:3, :])

--- a/prepare_data/kitti_util.py
+++ b/prepare_data/kitti_util.py
@@ -98,9 +98,10 @@ class KittiReader:
         frame_inds.sort()
         last_ind = frame_inds[-1]
         half_len = snippet_len // 2
+        print("[find_frame_indices] bef", frame_inds[:5], frame_inds[-5:])
         frame_inds = [index for index in frame_inds if half_len <= index <= last_ind-half_len]
         frame_inds = np.array(frame_inds, dtype=int)
-        print("[find_frame_indices]", frame_inds[:20])
+        print("[find_frame_indices] aft", frame_inds[:5], frame_inds[-5:])
         return frame_inds
 
 

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -34,14 +34,14 @@ def prepare_and_save_snippets(loader, dataset, split):
 
         print(f"\n{'=' * 50}\n[load drive] [{i}/{num_drives}] drive path: {snippet_path}")
         frame_indices = loader.load_drive(drive, opts.SNIPPET_LEN)
-        assert len(frame_indices) > 0
+        num_frames = len(frame_indices)
+        assert num_frames > 0
 
         with PathManager(data_paths) as pm:
-            num_frames = len(frame_indices)
             for k, index in enumerate(frame_indices):
                 example = loader.example_generator(index, opts.SNIPPET_LEN)
                 mean_depth = save_example(example, index, data_paths)
-                print_progress_status(f"Progress: mean depth={mean_depth:0.3f}, {k}/{num_frames}")
+                print_progress_status(f"Progress: mean depth={mean_depth:0.3f}, index={index}, {k}/{num_frames}")
             # if set_ok() was NOT excuted, the generated path is removed
             pm.set_ok()
         print("")

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -102,6 +102,8 @@ def create_validation_set(dataset):
     elif dataset == "kitti_odom":
         os.makedirs(dstpath, exist_ok=True)
         for drive in ["09", "10"]:
+            if os.path.isdir(os.path.join(dstpath, drive)):
+                shutil.rmtree(os.path.join(dstpath, drive))
             shutil.copytree(os.path.join(srcpath, drive), os.path.join(dstpath, drive))
 
     print(f"\n### create validation split for {dataset}")

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -11,12 +11,15 @@ from utils.util_funcs import print_progress_status
 from utils.util_class import PathManager
 
 
-def prepare_kitti_data():
-    for dataset in ["kitti_raw", "kitti_odom"]:
-        for split in ["test", "train"]:
+def prepare_kitti_data(dataset_in=None, split_in=None):
+    datasets = ["kitti_raw", "kitti_odom"] if dataset_in is None else [dataset_in]
+    splits = ["test", "train"] if split_in is None else [split_in]
+    for dataset in datasets:
+        for split in splits:
             loader = kitti_loader_factory(get_raw_data_path(dataset), dataset, split)
             prepare_and_save_snippets(loader, dataset, split)
-        create_validation_set(dataset)
+            if split == "test":
+                create_validation_set(dataset)
 
 
 def prepare_and_save_snippets(loader, dataset, split):
@@ -109,14 +112,6 @@ def create_validation_set(dataset):
     print(f"\n### create validation split for {dataset}")
 
 
-def prepare_single_dataset():
-    dataset = "kitti_odom"
-    split = "train"
-    loader = kitti_loader_factory(get_raw_data_path(dataset), dataset, split)
-    prepare_and_save_snippets(loader, dataset, split)
-
-
 if __name__ == "__main__":
     np.set_printoptions(precision=3, suppress=True)
-    prepare_kitti_data()
-    # prepare_single_dataset()
+    prepare_kitti_data("kitti_raw", "train")

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -6,14 +6,15 @@ import shutil
 
 import settings
 from config import opts, get_raw_data_path
-from prepare_data.kitti_loader import KittiDataLoader
+from prepare_data.kitti_loader import kitti_loader_factory
 from utils.util_funcs import print_progress_status
+from utils.util_class import PathManager
 
 
 def prepare_kitti_data():
     for dataset in ["kitti_raw", "kitti_odom"]:
-        for split in ["train", "test"]:
-            loader = KittiDataLoader(get_raw_data_path(dataset), dataset, split)
+        for split in ["test", "train"]:
+            loader = kitti_loader_factory(get_raw_data_path(dataset), dataset, split)
             prepare_and_save_snippets(loader, dataset, split)
         create_validation_set(dataset)
 
@@ -24,57 +25,61 @@ def prepare_and_save_snippets(loader, dataset, split):
     num_drives = len(loader.drive_list)
 
     for i, drive in enumerate(loader.drive_list):
-        snippet_path, pose_path, depth_path = get_destination_paths(dstpath, dataset, drive)
+        pose_avail, depth_avail = loader.kitti_reader.pose_avail, loader.kitti_reader.depth_avail
+        data_paths = get_destination_paths(dstpath, dataset, drive, pose_avail, depth_avail)
+        snippet_path = data_paths[0]
         if op.isdir(snippet_path):
             print(f"this drive may have already prepared, check this path completed: {snippet_path}")
             continue
 
         print(f"\n{'=' * 50}\n[load drive] [{i}/{num_drives}] drive path: {snippet_path}")
         frame_indices = loader.load_drive(drive, opts.SNIPPET_LEN)
-        if frame_indices.size == 0:
-            print("this drive is EMPTY")
-            continue
+        assert len(frame_indices) > 0
 
-        os.makedirs(snippet_path, exist_ok=True)
-        if loader.kitti_reader.pose_avail:
-            os.makedirs(pose_path, exist_ok=True)
-        if loader.kitti_reader.depth_avail:
-            os.makedirs(depth_path, exist_ok=True)
+        with PathManager(data_paths) as pm:
+            num_frames = len(frame_indices)
+            for k, index in enumerate(frame_indices):
+                example = loader.example_generator(index, opts.SNIPPET_LEN)
+                mean_depth = save_example(example, index, data_paths)
+                print_progress_status(f"- Progress: mean depth={mean_depth:0.3f}, {k}/{num_frames}")
+            # if set_ok() was NOT excuted, the generated path is removed
+            pm.set_ok()
 
-        num_frames = len(frame_indices)
-        for k, index in enumerate(frame_indices):
-            snippet = loader.snippet_generator(index, opts.SNIPPET_LEN)
-            index = snippet["index"]
-            frames = snippet["frames"]
-            filename = op.join(snippet_path, f"{index:06d}.png")
-            cv2.imwrite(filename, frames)
-
-            if "gt_poses" in snippet:
-                poses = snippet["gt_poses"]
-                filename = op.join(pose_path, f"{index:06d}.txt")
-                np.savetxt(filename, poses, fmt="%3.5f")
-
-            mean_depth = 0
-            if "gt_depth" in snippet:
-                depth = snippet["gt_depth"]
-                filename = op.join(depth_path, f"{index:06d}.txt")
-                np.savetxt(filename, depth, fmt="%3.5f")
-                mean_depth = np.mean(depth)
-
-            filename = op.join(snippet_path, "intrinsic.txt")
-            if not op.isfile(filename):
-                intrinsic = snippet["intrinsic"]
-                print("##### intrinsic parameters\n", intrinsic)
-                np.savetxt(filename, intrinsic, fmt="%3.5f")
-
-            # cv2.imshow("snippet frames", frames)
-            # cv2.waitKey(1)
-            print_progress_status(f"- Progress: mean depth={mean_depth:0.3f}, {k}/{num_frames}")
-        print("\t progress done")
+        print("\n\tprogress done")
     print(f"Data preparation of {dataset}_{split} is done")
 
 
-def get_destination_paths(dstpath, dataset, drive):
+def save_example(example, index, data_paths):
+    snippet_path, pose_path, depth_path = data_paths
+    frames = example["image"]
+    filename = op.join(snippet_path, f"{index:06d}.png")
+    cv2.imwrite(filename, frames)
+    center_y, center_x = (opts.IM_HEIGHT // 2, opts.IM_WIDTH // 2)
+
+    if "pose_gt" in example:
+        poses = example["pose_gt"]
+        filename = op.join(pose_path, f"{index:06d}.txt")
+        np.savetxt(filename, poses, fmt="%3.5f")
+
+    mean_depth = 0
+    if "depth_gt" in example:
+        depth = example["depth_gt"]
+        filename = op.join(depth_path, f"{index:06d}.txt")
+        np.savetxt(filename, depth, fmt="%3.5f")
+        mean_depth = depth[center_y - 10:center_y + 10, center_x - 10:center_x + 10].mean()
+
+    filename = op.join(snippet_path, "intrinsic.txt")
+    if not op.isfile(filename):
+        intrinsic = example["intrinsic"]
+        print("##### intrinsic parameters\n", intrinsic)
+        np.savetxt(filename, intrinsic, fmt="%3.5f")
+
+    # cv2.imshow("example frames", frames)
+    # cv2.waitKey(1)
+    return mean_depth
+
+
+def get_destination_paths(dstpath, dataset, drive, pose_avail, depth_avail):
     if dataset == "kitti_raw":
         drive_path = op.join(dstpath, f"{drive[0]}_{drive[1]}")
     elif dataset == "kitti_odom":
@@ -82,8 +87,8 @@ def get_destination_paths(dstpath, dataset, drive):
     else:
         raise ValueError()
 
-    pose_path = op.join(drive_path, "pose")
-    depth_path = op.join(drive_path, "depth")
+    pose_path = op.join(drive_path, "pose") if pose_avail else None
+    depth_path = op.join(drive_path, "depth") if depth_avail else None
     return drive_path, pose_path, depth_path
 
 
@@ -106,7 +111,7 @@ def create_validation_set(dataset):
 def prepare_single_dataset():
     dataset = "kitti_odom"
     split = "train"
-    loader = KittiDataLoader(get_raw_data_path(dataset), dataset, split)
+    loader = kitti_loader_factory(get_raw_data_path(dataset), dataset, split)
     prepare_and_save_snippets(loader, dataset, split)
 
 

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -32,7 +32,7 @@ def prepare_and_save_snippets(loader, dataset, split):
             print(f"this drive may have already prepared, check this path completed: {snippet_path}")
             continue
 
-        print(f"\n{'=' * 50}\n[load drive] [{i}/{num_drives}] drive path: {snippet_path}")
+        print(f"\n{'=' * 50}\n[load drive] [{i+1}/{num_drives}] drive path: {snippet_path}")
         frame_indices = loader.load_drive(drive, opts.SNIPPET_LEN)
         num_frames = len(frame_indices)
         assert num_frames > 0

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -41,11 +41,10 @@ def prepare_and_save_snippets(loader, dataset, split):
             for k, index in enumerate(frame_indices):
                 example = loader.example_generator(index, opts.SNIPPET_LEN)
                 mean_depth = save_example(example, index, data_paths)
-                print_progress_status(f"- Progress: mean depth={mean_depth:0.3f}, {k}/{num_frames}")
+                print_progress_status(f"Progress: mean depth={mean_depth:0.3f}, {k}/{num_frames}")
             # if set_ok() was NOT excuted, the generated path is removed
             pm.set_ok()
-
-        print("\n\tprogress done")
+        print("")
     print(f"Data preparation of {dataset}_{split} is done")
 
 
@@ -71,7 +70,7 @@ def save_example(example, index, data_paths):
     filename = op.join(snippet_path, "intrinsic.txt")
     if not op.isfile(filename):
         intrinsic = example["intrinsic"]
-        print("##### intrinsic parameters\n", intrinsic)
+        print("intrinsic parameters\n", intrinsic)
         np.savetxt(filename, intrinsic, fmt="%3.5f")
 
     # cv2.imshow("example frames", frames)

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -76,6 +76,12 @@ def save_example(example, index, data_paths):
         print("intrinsic parameters\n", intrinsic)
         np.savetxt(filename, intrinsic, fmt="%3.5f")
 
+    if "stereo_T_LR" in example:
+        filename = op.join(snippet_path, "stereo_T_LR.txt")
+        if not op.isfile(filename):
+            extrinsic = example["stereo_T_LR"]
+            np.savetxt(filename, extrinsic, fmt="%3.5f")
+
     # cv2.imshow("example frames", frames)
     # cv2.waitKey(1)
     return mean_depth
@@ -114,4 +120,4 @@ def create_validation_set(dataset):
 
 if __name__ == "__main__":
     np.set_printoptions(precision=3, suppress=True)
-    prepare_kitti_data("kitti_raw", "train")
+    prepare_kitti_data("kitti_raw", "test")

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import settings
 from config import opts
+from utils.util_class import PathManager
 from tfrecords.tfrecord_writer import TfrecordMaker
 
 
@@ -18,9 +19,12 @@ def convert_to_tfrecords():
         if op.isdir(tfrpath):
             print("[convert_to_tfrecords] tfrecord already created in", tfrpath)
         else:
-            os.makedirs(tfrpath, exist_ok=True)
-            tfrmaker = TfrecordMaker(srcpath, tfrpath, opts.STEREO, opts.IM_WIDTH)
-            tfrmaker.make()
+            with PathManager([tfrpath]) as pm:
+                os.makedirs(tfrpath, exist_ok=True)
+                tfrmaker = TfrecordMaker(srcpath, tfrpath, opts.STEREO, opts.IM_WIDTH)
+                tfrmaker.make()
+                # if set_ok() was NOT excuted, the generated path is removed
+                pm.set_ok()
 
 
 if __name__ == "__main__":

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -19,7 +19,7 @@ def convert_to_tfrecords():
             print("[convert_to_tfrecords] tfrecord already created in", tfrpath)
         else:
             os.makedirs(tfrpath, exist_ok=True)
-            tfrmaker = TfrecordMaker(srcpath, tfrpath)
+            tfrmaker = TfrecordMaker(srcpath, tfrpath, opts.STEREO, opts.IM_WIDTH)
             tfrmaker.make()
 
 

--- a/tfrecords/data_feeders.py
+++ b/tfrecords/data_feeders.py
@@ -11,7 +11,7 @@ import utils.convert_pose as cp
 
 def feeder_factory(file_list, reader_type, feeder_type="npyfile", stereo=False):
     if feeder_type == "npyfile":
-        if stereo:
+        if stereo and reader_type != "extrinsic":
             FeederClass = NpyFileFeederStereoLeft
         else:
             FeederClass = NpyFileFeeder
@@ -21,11 +21,13 @@ def feeder_factory(file_list, reader_type, feeder_type="npyfile", stereo=False):
     if reader_type == "image":
         reader = ImageReaderStereo() if stereo else ImageReader()
     elif reader_type == "intrinsic":
-        reader = IntrinsicReaderStereo() if stereo else IntrinsicReader()
+        reader = NpyTxtReaderStereo() if stereo else NpyTxtReader()
     elif reader_type == "depth":
         reader = DepthReaderStereo() if stereo else DepthReader()
     elif reader_type == "pose":
         reader = PoseReaderStereo() if stereo else PoseReader()
+    elif reader_type == "extrinsic":
+        reader = NpyTxtReader()
     else:
         raise WrongInputException("Wrong reader type: " + reader_type)
 
@@ -225,13 +227,13 @@ class PoseReaderStereo(PoseReader):
         return [left, right]
 
 
-class IntrinsicReader(FileReader):
+class NpyTxtReader(FileReader):
     def read_file(self, filename):
         data = np.loadtxt(filename)
         return data.astype(np.float32)
 
 
-class IntrinsicReaderStereo(IntrinsicReader):
+class NpyTxtReaderStereo(NpyTxtReader):
     def split_data(self, data):
         intrin_width = 3
         left, right = data[:, :intrin_width], data[:, intrin_width:]

--- a/tfrecords/data_feeders.py
+++ b/tfrecords/data_feeders.py
@@ -1,5 +1,6 @@
 import numpy as np
 import tensorflow as tf
+from utils.util_class import WrongInputException
 
 
 class FeederBase:
@@ -24,8 +25,7 @@ class FeederBase:
             elif value.dtype == np.float32:
                 self.decode_type = "tf.float32"
             else:
-                print("numpy type:", value.dtype)
-                raise TypeError()
+                raise WrongInputException(f"[FeederBase] Wrong numpy type: {value.dtype}")
             self.parse_type = "tf.string"
             self.shape = list(value.shape)
 
@@ -34,8 +34,7 @@ class FeederBase:
             self.shape = None
 
         else:
-            print("type:", type(value))
-            raise TypeError()
+            raise WrongInputException(f"[FeederBase] Wrong type: {type(value)}")
 
     @staticmethod
     def _bytes_feature(value):
@@ -67,15 +66,8 @@ class FileFeeder(FeederBase):
 
     def get_next(self):
         self.idx = self.idx + 1
-        if self.idx >= len(self.files):
-            raise IndexError()
-
+        assert self.idx < len(self), f"[FileFeeder] index error: {self.idx} >= {len(self)}"
         onedata = self.file_reader(self.files[self.idx])
-        if onedata is None:
-            raise FileNotFoundError(self.files[self.idx])
-
-        # wrap a single raw data as tf.train.Features()
-        features = dict()
         return self.convert_to_feature(onedata)
 
     def convert_to_feature(self, value):
@@ -103,9 +95,7 @@ class ConstArrayFeeder(FeederBase):
 
     def get_next(self):
         self.idx = self.idx + 1
-        if self.idx >= self.size:
-            raise IndexError()
-        
+        assert self.idx < len(self), f"[FileFeeder] index error: {self.idx} >= {len(self)}"
         return self.convert_to_feature(self.data)
 
     def convert_to_feature(self, value):

--- a/tfrecords/tfrecord_writer.py
+++ b/tfrecords/tfrecord_writer.py
@@ -1,14 +1,10 @@
 import os.path as op
 from glob import glob
 import tensorflow as tf
-import cv2
-import numpy as np
 import json
 
 import settings
-from config import opts
 import utils.util_funcs as uf
-import utils.convert_pose as cp
 import tfrecords.data_feeders as df
 
 
@@ -49,28 +45,21 @@ class TfrecordMaker:
 
     def create_feeders(self):
         image_files, intrin_files, depth_files, pose_files = self.list_sequence_files()
+        feeders = {"image": df.feeder_factory(image_files, "image", "npyfile", self.stereo),
+                   "intrinsic": df.feeder_factory(intrin_files, "intrinsic", "npyfile", self.stereo),
+                   }
+        if self.depth_avail:
+            feeders["depth_gt"] = df.feeder_factory(depth_files, "depth", "npyfile", self.stereo)
+        if self.pose_avail:
+            feeders["pose_gt"] = df.feeder_factory(pose_files, "pose", "npyfile", self.stereo)
 
         if self.stereo:
-            feeders = {"image": df.NpyFileFeederStereoLeft(image_files, image_reader),
-                       "intrinsic": df.NpyFileFeederStereoLeft(intrin_files, npytxt_reader),
-                       }
-            if self.depth_avail:
-                feeders["depth_gt"] = df.NpyFileFeederStereoLeft(depth_files, depth_reader)
-            if self.pose_avail:
-                feeders["pose_gt"] = df.NpyFileFeederStereoLeft(pose_files, pose_reader)
             # add right side data
             feeders_rig = dict()
             for name, left_feeder in feeders.items():
+                print("left feeder", name, type(left_feeder))
                 feeders_rig[name + "_R"] = df.NpyFileFeederStereoRight(left_feeder)
             feeders.update(feeders_rig)
-        else:
-            feeders = {"image": df.NpyFileFeeder(image_files, image_reader),
-                       "intrinsic": df.NpyFileFeeder(intrin_files, npytxt_reader),
-                       }
-            if self.depth_avail:
-                feeders["depth_gt"] = df.NpyFileFeeder(depth_files, depth_reader)
-            if self.pose_avail:
-                feeders["pose_gt"] = df.NpyFileFeeder(pose_files, pose_reader)
 
         return feeders
 
@@ -135,85 +124,3 @@ class TfrecordMaker:
         # serialize the data.
         serialized = example.SerializeToString()
         return serialized
-
-
-# ==================== file readers ====================
-
-def image_reader(filename):
-    """
-    reorder image: [src0 src1 tgt src2 src3] -> [src1 src2 src3 src4 tgt]
-    """
-    image = cv2.imread(filename)
-    height = int(image.shape[0] // opts.SNIPPET_LEN)
-    half_len = int(opts.SNIPPET_LEN // 2)
-    # TODO IMPORTANT!
-    #   image in 'srcdata': [src--, src-, target, src+, src++]
-    #   reordered in 'tfrecords': [src--, src-, src+, src++, target]
-    src_up = image[:height*half_len]
-    target = image[height*half_len:height*(half_len+1)]
-    src_dw = image[height*(half_len+1):]
-    reordered = np.concatenate([src_up, src_dw, target], axis=0)
-    return reordered
-
-
-def pose_reader(filename):
-    """
-    quaternion based pose to transformation matrix omitting target pose (identity)
-    order: [src0 src1 tgt src2 src3] -> [src0 src1 src2 src3]
-    shape: [5, 7] -> [4, 4, 4]
-    """
-    poses = np.loadtxt(filename)
-    half_len = int(opts.SNIPPET_LEN // 2)
-    poses = np.delete(poses, half_len, 0)
-    pose_mats = []
-    for pose in poses:
-        tmat = cp.pose_quat2matr(pose[:7])
-        if len(pose) == 14:
-            tmat_rig = cp.pose_quat2matr(pose[7:])
-            tmat = np.concatenate([tmat, tmat_rig], axis=1)
-        pose_mats.append(tmat)
-    pose_mats = np.stack(pose_mats, axis=0)
-    return pose_mats.astype(np.float32)
-
-
-def npytxt_reader(filename):
-    data = np.loadtxt(filename)
-    return data.astype(np.float32)
-
-
-def depth_reader(filename):
-    data = np.loadtxt(filename)
-    # add channel dimension
-    data = np.expand_dims(data, -1)
-    return data.astype(np.float32)
-
-
-# ==================== test file readers ====================
-
-def test_image_reader():
-    filename = op.join(opts.DATAPATH_SRC, "kitti_raw_train", "2011_09_26_0001", "000024.png")
-    original = cv2.imread(filename)
-    reordered = image_reader(filename)
-    assert (original.shape == reordered.shape)
-    cv2.imshow("original", original)
-    cv2.imshow("reordered", reordered)
-    cv2.waitKey()
-
-
-def test_pose_reader():
-    filename = op.join(opts.DATAPATH_SRC, "kitti_raw_train", "2011_09_26_0001", "pose", "000040.txt")
-    pose_quat = np.loadtxt(filename)
-    pose_tmat = pose_reader(filename)
-    print("quaternion pose:", pose_quat[0])
-    print("matrix pose:\n", pose_tmat[0])
-    assert pose_tmat.shape == (4, 4, 4)
-
-
-def test():
-    np.set_printoptions(precision=3, suppress=True)
-    test_image_reader()
-    test_pose_reader()
-
-
-if __name__ == "__main__":
-    test()

--- a/utils/util_class.py
+++ b/utils/util_class.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 
 class TrainException(Exception):
     def __init__(self, msg):
@@ -7,3 +10,28 @@ class TrainException(Exception):
 class WrongInputException(Exception):
     def __init__(self, msg):
         super().__init__(msg)
+
+
+class PathManager:
+    def __init__(self, paths):
+        self.paths = paths
+        self.safe_exit = False
+
+    def __enter__(self):
+        for path in self.paths:
+            if path is not None:
+                os.makedirs(path, exist_ok=True)
+        return self
+
+    def set_ok(self):
+        self.safe_exit = True
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.safe_exit is False:
+            print("[PathManager] the process is NOT ended properly, remove the working paths")
+            for path in self.paths:
+                if path is not None and os.path.isdir(path):
+                    print("    remove:", path)
+                    shutil.rmtree(path)
+            # to ensure the process stop here
+            assert False


### PR DESCRIPTION
## kitti_depth_generator.py

lidar 데이터로부터 depth map 만드는 알고리즘 수정
기존에는 geonet 코드를 거의 가져왔는데 이번에 거의 새로 작성

## kitti_loader.py

stereo 데이터를 불러와서 stereo example을 만들수 있는 `KittiDataLoaderStereo` 구현
stereo 데이터는 두 데이터를 옆으로 붙여서 출력한다.
두 카메라 사이의 extrinsic도 `"stereo_T_LR"`이라는 키로 출력

## prepare_data_main.py

`PathManager` 이용해서 데이터를 만들다 중간에 멈추면 미완성된 폴더 지우기

## create_tfrecords_main.py

`PathManager` 이용해서 데이터를 만들다 중간에 멈추면 미완성된 폴더 지우기

## data_feeders.py

파일 읽고 전처리하는 함수들을 모두 클래스화하고 stereo 데이터까지 처리할 수 있도록 구현
데이터 종류에 따라 데이터를 파일에서 읽어오는 `FileReader`와 
`tf.train.Feature()`를 `FeederBase`를 조합해주는 `feeder_factory()`구현
