### PR TITLE
Improve prepare data

### DIFF
--- a/prepare_data/city_reader.py
+++ b/prepare_data/city_reader.py
@@ -1,0 +1,163 @@
+import os.path as op
+from glob import glob
+import numpy as np
+
+import utils.convert_pose as cp
+
+"""
+when 'stereo' is True, 'get_xxx' function returns two data
+"""
+
+
+class CityReader:
+    def __init__(self, stereo=False):
+        self.static_frames = self.read_static_frames()
+        self.stereo = stereo
+        self.drive_loader = None
+        self.pose_avail = False
+        self.depth_avail = True
+        self.T_left_right = None
+        self.frame_count = [0, 0]
+
+    def read_static_frames(self):
+        filename = self.static_frame_filename()
+        with open(filename, "r") as fr:
+            lines = fr.readlines()
+            static_frames = [line.strip("\n") for line in lines]
+        return static_frames
+
+    def static_frame_filename(self):
+        raise NotImplementedError()
+
+    def remove_static_frames(self, frames, drive=""):
+        valid_frames = [frame for frame in frames if frame not in self.static_frames]
+        return valid_frames
+
+    def list_drive_paths(self, split, base_path):
+        raise NotImplementedError()
+
+    def verify_drives(self, drives, base_path):
+        # verify drive paths
+        verified_drives = []
+        for drive in drives:
+            drive_path = self.make_raw_data_path(base_path, drive)
+            if not op.isdir(drive_path):
+                continue
+            frame_inds = self.find_frame_indices(drive_path, 5)
+            if len(frame_inds) == 0:
+                continue
+            verified_drives.append(drive)
+
+        print("drive list:", verified_drives)
+        print("frame counts:", dict(zip(["total", "non-static"], self.frame_count)))
+        return verified_drives
+
+    def make_raw_data_path(self, base_path, drive):
+        raise NotImplementedError()
+
+    def create_drive_loader(self, base_path, drive):
+        raise NotImplementedError()
+
+    def find_frame_indices(self, drive_path, snippet_len):
+        raise NotImplementedError()
+
+    def find_last_index(self, drive_path):
+        frame_files = self.find_frame_files(drive_path)
+        last_file = frame_files[-1]
+        last_index = last_file.strip("\n").split("/")[-1][:-4]
+        return int(last_index)
+
+    def find_frame_files(self, drive_path):
+        raise NotImplementedError()
+
+    def get_image(self, index):
+        images = self.drive_loader.get_rgb(index)
+        if self.stereo:
+            return np.array(images[0]), np.array(images[1])
+        else:
+            return np.array(images[0])
+
+    def get_intrinsic(self):
+        intrinsic = self.drive_loader.calib.K_cam2
+        if self.stereo:
+            intrinsic_rig = self.drive_loader.calib.K_cam3
+            return intrinsic, intrinsic_rig
+        else:
+            return intrinsic
+
+    def get_quat_pose(self, index):
+        raise NotImplementedError()
+
+    def get_depth_map(self, frame_idx, drive_path, raw_img_shape, target_shape):
+        raise NotImplementedError()
+
+    def get_stereo_extrinsic(self):
+        return self.T_left_right
+
+    def update_stereo_extrinsic(self):
+        cal = self.drive_loader.calib
+        T_cam2_cam3 = np.dot(cal.T_cam2_velo, np.linalg.inv(cal.T_cam3_velo))
+        self.T_left_right = T_cam2_cam3
+        print("update stereo extrinsic T_left_right =\n", self.T_left_right)
+
+
+class CitySequenceReader(CityReader):
+    def __init__(self, stereo=False):
+        super().__init__(stereo)
+        self.pose_avail = False
+        self.depth_avail = True
+
+    def static_frame_filename(self):
+        return op.join(op.dirname(op.abspath(__file__)), "resources", "city_seq_static_frames.txt")
+
+    def list_drive_paths(self, split, base_path):
+        filename = op.join(op.dirname(op.abspath(__file__)), "resources", f"kitti_raw_{split}_scenes.txt")
+        with open(filename, "r") as f:
+            drives = f.readlines()
+            drives.sort()
+            drives = [tuple(drive.strip("\n").split()) for drive in drives]
+            drives = self.verify_drives(drives, base_path)
+            return drives
+
+    def create_drive_loader(self, base_path, drive):
+        print(f"[create_drive_loader] pose avail: {self.pose_avail}, depth avail: {self.depth_avail}")
+
+        date, drive_id = drive
+        self.drive_loader = pykitti.raw(base_path, date, drive_id)
+
+    def make_raw_data_path(self, base_path, drive):
+        drive_path = op.join(base_path, drive[0], f"{drive[0]}_drive_{drive[1]}_sync")
+        return drive_path
+
+    def find_frame_indices(self, drive_path, snippet_len):
+        raise NotImplementedError()
+
+    def find_frame_files(self, drive_path):
+        frame_pattern = op.join(drive_path, "image_02", "data", "*.png")
+        frame_files = glob(frame_pattern)
+        frame_files.sort()
+        return frame_files
+
+    def get_quat_pose(self, index):
+        T_w_imu = self.drive_loader.oxts[index].T_w_imu
+        T_imu_cam2 = np.linalg.inv(self.drive_loader.calib.T_cam2_imu)
+        T_w_cam2 = np.dot(T_w_imu, T_imu_cam2)
+        pose_lef = cp.pose_matr2quat(T_w_cam2)
+        if self.stereo:
+            T_cam2_cam3 = self.T_left_right
+            T_w_cam3 = np.dot(T_w_cam2, T_cam2_cam3)
+            pose_rig = cp.pose_matr2quat(T_w_cam3)
+            return pose_lef, pose_rig
+        else:
+            return pose_lef
+
+    def get_depth_map(self, frame_idx, drive_path, original_shape, target_shape):
+        velo_data = self.drive_loader.get_velo(frame_idx)
+        T_cam2_velo, K_cam2 = self.drive_loader.calib.T_cam2_velo, self.drive_loader.calib.K_cam2
+        depth = kdg.generate_depth_map(velo_data, T_cam2_velo, K_cam2, original_shape, target_shape)
+        if self.stereo:
+            T_cam3_velo, K_cam3 = self.drive_loader.calib.T_cam3_velo, self.drive_loader.calib.K_cam3
+            depth_rig = kdg.generate_depth_map(velo_data, T_cam3_velo, K_cam3, original_shape, target_shape)
+            return depth, depth_rig
+        else:
+            return depth

--- a/prepare_data/example_maker.py
+++ b/prepare_data/example_maker.py
@@ -181,18 +181,20 @@ class ExampleMakerStereo(ExampleMaker):
 def test_kitti_loader():
     np.set_printoptions(precision=3, suppress=True, linewidth=150)
     dataset = "kitti_raw"
-    loader = dataset_loader_factory(get_raw_data_path(dataset), dataset, "train")
+    maker, reader = dataset_loader_factory(get_raw_data_path(dataset), dataset, "train")
     delay = 0
     height, width = opts.IM_HEIGHT, opts.IM_WIDTH
+    drive_paths = reader.list_drive_paths()
 
-    for drive in loader.drive_list:
-        frame_indices = loader.load_drive(drive, opts.SNIPPET_LEN)
-        if frame_indices.size == 0:
+    for drive_path in drive_paths:
+        frame_indices = reader.init_drive(drive_path)
+        maker.set_reader(reader)
+        if len(frame_indices) == 0:
             print("this drive is EMPTY")
             continue
 
         for index in frame_indices:
-            example = loader.get_example(index, opts.SNIPPET_LEN)
+            example = maker.get_example(index)
             index = example["index"]
             frames = example["image"]
             poses = example["pose_gt"]

--- a/prepare_data/kitti_loader.py
+++ b/prepare_data/kitti_loader.py
@@ -3,78 +3,69 @@ import numpy as np
 
 import settings
 from config import opts, get_raw_data_path
-import prepare_data.kitti_util as ku
+import prepare_data.kitti_reader as ku
 import utils.convert_pose as cp
 from utils.util_class import WrongInputException
 
 """
-KittiDataLoader: generates training example, main function is snippet_generator()
+ExampleMaker: generates training example, main function is snippet_generator()
 KittiReader: reads data from files
 """
 
 
-def kitti_loader_factory(base_path, dataset, split):
-    stereo = opts.STEREO
+def dataset_loader_factory(raw_data_path, dataset, split, stereo=opts.STEREO, snippet_len=opts.SNIPPET_LEN):
     if dataset == "kitti_raw" and split == "train":
-        data_reader = ku.KittiRawTrainUtil(stereo)
+        data_reader = ku.KittiRawTrainReader(raw_data_path, stereo, snippet_len // 2)
     elif dataset == "kitti_raw" and split == "test":
-        data_reader = ku.KittiRawTestUtil(stereo)
+        data_reader = ku.KittiRawTestReader(raw_data_path, stereo, snippet_len // 2)
     elif dataset == "kitti_odom" and split == "train":
-        data_reader = ku.KittiOdomTrainReader(stereo)
+        data_reader = ku.KittiOdomTrainReader(raw_data_path, stereo, snippet_len // 2)
     elif dataset == "kitti_odom" and split == "test":
-        data_reader = ku.KittiOdomTestReader(stereo)
+        data_reader = ku.KittiOdomTestReader(raw_data_path, stereo, snippet_len // 2)
     else:
         raise WrongInputException(f"Wrong dataset and split: {dataset}, {split}")
 
     if stereo:
-        return KittiDataLoaderStereo(base_path, split, data_reader)
+        snippet_maker = ExampleMakerStereo(raw_data_path, snippet_len)
     else:
-        return KittiDataLoader(base_path, split, data_reader)
+        snippet_maker = ExampleMaker(raw_data_path, snippet_len)
+    return snippet_maker, data_reader
 
 
-class KittiDataLoader:
-    def __init__(self, base_path, split, reader):
+class ExampleMaker:
+    def __init__(self, base_path, snippet_len):
         self.base_path = base_path
-        self.kitti_reader = reader
-        self.drive_list = self.kitti_reader.list_drives(split, base_path)
+        self.snippet_len = snippet_len
+        self.data_reader = ku.KittiRawTrainReader("", True, 2)
         self.drive_path = ""
         self.frame_inds = []
-        self.last_index = 0
-        self.num_frames = 0
 
-    def load_drive(self, drive, snippet_len):
-        self.kitti_reader.create_drive_loader(self.base_path, drive)
-        self.kitti_reader.update_stereo_extrinsic()
-        self.drive_path = self.kitti_reader.make_drive_path(self.base_path, drive)
-        self.frame_inds = self.kitti_reader.find_frame_indices(self.drive_path, snippet_len)
-        self.last_index = self.kitti_reader.find_last_index(self.drive_path)
-        self.num_frames = len(self.frame_inds)
-        print(f"frame_indices: {self.frame_inds[0]} ~ {self.frame_inds[-1]}, last={self.last_index}")
-        return self.frame_inds
+    def set_reader(self, reader):
+        self.data_reader = reader
 
-    def example_generator(self, index, snippet_len):
-        indices = self.make_snippet_indices(index, snippet_len)
+    def get_example(self, index):
+        indices = self.make_snippet_indices(index)
         example = dict()
         example["index"] = index
         example["image"], raw_img_shape = self.load_snippet_frames(indices)
         example["intrinsic"] = self.load_intrinsic(raw_img_shape)
-        if self.kitti_reader.pose_avail:
-            example["pose_gt"] = self.load_snippet_poses(indices, snippet_len)
-        if self.kitti_reader.depth_avail:
+        if self.data_reader.pose_avail:
+            example["pose_gt"] = self.load_snippet_poses(indices)
+        if self.data_reader.depth_avail:
             example["depth_gt"] = self.load_frame_depth(indices, self.drive_path, raw_img_shape)
         return example
 
-    def make_snippet_indices(self, frame_idx, snippet_len):
-        halflen = snippet_len // 2
+    def make_snippet_indices(self, frame_idx):
+        halflen = self.snippet_len // 2
         indices = np.arange(frame_idx-halflen, frame_idx+halflen+1)
-        indices = np.clip(indices, 0, self.last_index).tolist()
+        indices = np.clip(indices, 0, self.data_reader.last_index).tolist()
         return indices
 
     def load_snippet_frames(self, frame_indices):
         frames = []
         raw_img_shape = ()
         for index in frame_indices:
-            frame = self.kitti_reader.get_image(index)
+            frame = self.data_reader.get_image(index)
             raw_img_shape = frame.shape[:2]
             frame = cv2.resize(frame, dsize=(opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_LINEAR)
             frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
@@ -83,16 +74,14 @@ class KittiDataLoader:
         frames = np.concatenate(frames, axis=0)
         return frames, raw_img_shape
 
-    def load_snippet_poses(self, frame_indices, snippet_len):
+    def load_snippet_poses(self, frame_indices):
         poses = []
         for ind in frame_indices:
-            pose = self.kitti_reader.get_quat_pose(ind)
+            pose = self.data_reader.get_quat_pose(ind)
             poses.append(pose)
 
         poses = np.stack(poses, axis=0)
-        # print("poses bef\n", poses)
-        poses = self.to_local_pose(poses, snippet_len // 2)
-        # print("poses local\n", poses)
+        poses = self.to_local_pose(poses, self.snippet_len // 2)
         return poses
 
     def to_local_pose(self, poses, target_index):
@@ -109,11 +98,11 @@ class KittiDataLoader:
 
     def load_frame_depth(self, frame_idx, drive_path, raw_img_shape):
         dst_shape = (opts.IM_HEIGHT, opts.IM_WIDTH)
-        depth_map = self.kitti_reader.get_depth_map(frame_idx, drive_path, raw_img_shape, dst_shape)
+        depth_map = self.data_reader.get_depth_map(frame_idx, drive_path, raw_img_shape, dst_shape)
         return depth_map
 
     def load_intrinsic(self, raw_img_shape):
-        intrinsic = self.kitti_reader.get_intrinsic()
+        intrinsic = self.data_reader.get_intrinsic()
         sx = opts.IM_WIDTH / raw_img_shape[1]
         sy = opts.IM_HEIGHT / raw_img_shape[0]
         out = intrinsic.copy()
@@ -124,29 +113,29 @@ class KittiDataLoader:
         return out
 
 
-class KittiDataLoaderStereo(KittiDataLoader):
-    def __init__(self, base_path, split, reader):
-        super().__init__(base_path, split, reader)
+class ExampleMakerStereo(ExampleMaker):
+    def __init__(self, base_path, snippet_len):
+        super().__init__(base_path, snippet_len)
 
-    def example_generator(self, index, snippet_len):
-        indices = self.make_snippet_indices(index, snippet_len)
+    def get_example(self, index):
+        indices = self.make_snippet_indices(index)
         example = dict()
         example["index"] = index
         example["image"], raw_img_shape = self.load_snippet_frames_stereo(indices)
         example["intrinsic"] = self.load_intrinsic_stereo(raw_img_shape)
-        if self.kitti_reader.pose_avail:
-            example["pose_gt"] = self.load_snippet_poses_stereo(indices, snippet_len)
-        if self.kitti_reader.depth_avail:
+        if self.data_reader.pose_avail:
+            example["pose_gt"] = self.load_snippet_poses_stereo(indices)
+        if self.data_reader.depth_avail:
             example["depth_gt"] = self.load_frame_depth_stereo(index, self.drive_path, raw_img_shape)
-        if self.kitti_reader.stereo:
-            example["stereo_T_LR"] = self.kitti_reader.get_stereo_extrinsic()
+        if self.data_reader.stereo:
+            example["stereo_T_LR"] = self.data_reader.get_stereo_extrinsic()
         return example
 
     def load_snippet_frames_stereo(self, frame_indices):
         frames = []
         raw_img_shape = ()
         for ind in frame_indices:
-            img_lef, img_rig = self.kitti_reader.get_image(ind)
+            img_lef, img_rig = self.data_reader.get_image(ind)
             raw_img_shape = img_lef.shape[:2]
             img_lef = cv2.resize(img_lef, (opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_LINEAR)
             img_lef = cv2.cvtColor(img_lef, cv2.COLOR_RGB2BGR)
@@ -159,7 +148,7 @@ class KittiDataLoaderStereo(KittiDataLoader):
         return frames, raw_img_shape
 
     def load_intrinsic_stereo(self, raw_img_shape):
-        intrin_lef, intrin_rig = self.kitti_reader.get_intrinsic()
+        intrin_lef, intrin_rig = self.data_reader.get_intrinsic()
         intrinsic = np.concatenate([intrin_lef, intrin_rig], axis=1)
         sx = opts.IM_WIDTH / raw_img_shape[1]
         sy = opts.IM_HEIGHT / raw_img_shape[0]
@@ -167,24 +156,24 @@ class KittiDataLoaderStereo(KittiDataLoader):
         intrinsic[1, :] = intrinsic[1, :] * sy
         return intrinsic
 
-    def load_snippet_poses_stereo(self, frame_indices, snippet_len):
+    def load_snippet_poses_stereo(self, frame_indices):
         pose_seq_lef = []
         pose_seq_rig = []
         for ind in frame_indices:
-            pose_lef, pose_rig = self.kitti_reader.get_quat_pose(ind)
+            pose_lef, pose_rig = self.data_reader.get_quat_pose(ind)
             pose_seq_lef.append(pose_lef)
             pose_seq_rig.append(pose_rig)
 
         pose_seq_lef = np.stack(pose_seq_lef, axis=0)
         pose_seq_rig = np.stack(pose_seq_rig, axis=0)
-        pose_seq_lef = self.to_local_pose(pose_seq_lef, snippet_len//2)
-        pose_seq_rig = self.to_local_pose(pose_seq_rig, snippet_len//2)
+        pose_seq_lef = self.to_local_pose(pose_seq_lef, self.snippet_len // 2)
+        pose_seq_rig = self.to_local_pose(pose_seq_rig, self.snippet_len // 2)
         poses = np.concatenate([pose_seq_lef, pose_seq_rig], axis=1)
         return poses
 
     def load_frame_depth_stereo(self, frame_idx, drive_path, raw_img_shape):
         dst_shape = (opts.IM_HEIGHT, opts.IM_WIDTH)
-        depth_lef, depth_rig = self.kitti_reader.get_depth_map(frame_idx, drive_path, raw_img_shape, dst_shape)
+        depth_lef, depth_rig = self.data_reader.get_depth_map(frame_idx, drive_path, raw_img_shape, dst_shape)
         depth = np.concatenate([depth_lef, depth_rig], axis=1)
         return depth
 
@@ -192,7 +181,7 @@ class KittiDataLoaderStereo(KittiDataLoader):
 def test_kitti_loader():
     np.set_printoptions(precision=3, suppress=True, linewidth=150)
     dataset = "kitti_raw"
-    loader = kitti_loader_factory(get_raw_data_path(dataset), dataset, "train")
+    loader = dataset_loader_factory(get_raw_data_path(dataset), dataset, "train")
     delay = 0
     height, width = opts.IM_HEIGHT, opts.IM_WIDTH
 
@@ -203,7 +192,7 @@ def test_kitti_loader():
             continue
 
         for index in frame_indices:
-            example = loader.example_generator(index, opts.SNIPPET_LEN)
+            example = loader.get_example(index, opts.SNIPPET_LEN)
             index = example["index"]
             frames = example["image"]
             poses = example["pose_gt"]

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -7,7 +7,7 @@ import glob
 
 import settings
 from config import opts, get_raw_data_path
-from prepare_data.kitti_loader import kitti_loader_factory
+from prepare_data.kitti_loader import dataset_loader_factory
 from utils.util_funcs import print_progress_status
 from utils.util_class import PathManager
 
@@ -20,33 +20,37 @@ def prepare_kitti_data(dataset_in=None, split_in=None):
             if split == "val":
                 create_validation_set(dataset, "test")
             else:
-                loader = kitti_loader_factory(get_raw_data_path(dataset), dataset, split)
-                prepare_and_save_snippets(loader, dataset, split)
+                snippet_maker, data_reader = \
+                    dataset_loader_factory(get_raw_data_path(dataset), dataset, split)
+                prepare_and_save_snippets(snippet_maker, data_reader, dataset, split)
 
 
-def prepare_and_save_snippets(loader, dataset, split):
+def prepare_and_save_snippets(snippet_maker, data_reader, dataset, split):
     dstpath = op.join(opts.DATAPATH_SRC, f"{dataset}_{split}")
     os.makedirs(dstpath, exist_ok=True)
-    num_drives = len(loader.drive_list)
+    drive_paths = data_reader.list_drive_paths()
+    num_drives = len(drive_paths)
 
-    for i, drive in enumerate(loader.drive_list):
-        pose_avail, depth_avail = loader.kitti_reader.pose_avail, loader.kitti_reader.depth_avail
-        data_paths = get_destination_paths(dstpath, dataset, drive, pose_avail, depth_avail)
-        snippet_path = data_paths[0]
-        if op.isdir(snippet_path):
-            print(f"this drive may have already prepared, check this path completed: {snippet_path}")
-            continue
-
-        print(f"\n{'=' * 50}\n[load drive] [{i+1}/{num_drives}] drive path: {snippet_path}")
-        frame_indices = loader.load_drive(drive, opts.SNIPPET_LEN)
+    for i, drive_path in enumerate(drive_paths):
+        frame_indices = data_reader.init_drive(drive_path)
         num_frames = len(frame_indices)
         assert num_frames > 0
 
+        data_paths = data_reader.make_saving_paths(dstpath, drive_path)
+        image_path = data_paths[0]
+        if op.isdir(image_path):
+            print(f"this drive may have already prepared, check this path completed: {image_path}")
+            continue
+
+        print(f"\n{'=' * 50}\n[load drive] [{i+1}/{num_drives}] drive path: {image_path}")
+        snippet_maker.set_reader(data_reader)
         with PathManager(data_paths) as pm:
             for k, index in enumerate(frame_indices):
-                example = loader.example_generator(index, opts.SNIPPET_LEN)
+                example = snippet_maker.get_example(index)
                 mean_depth = save_example(example, index, data_paths)
                 print_progress_status(f"Progress: mean depth={mean_depth:0.3f}, index={index}, {k}/{num_frames}")
+                if k > 5:
+                    break
             # if set_ok() was NOT excuted, the generated path is removed
             pm.set_ok()
         print("")
@@ -54,9 +58,9 @@ def prepare_and_save_snippets(loader, dataset, split):
 
 
 def save_example(example, index, data_paths):
-    snippet_path, pose_path, depth_path = data_paths
+    image_path, pose_path, depth_path = data_paths
     frames = example["image"]
-    filename = op.join(snippet_path, f"{index:06d}.png")
+    filename = op.join(image_path, f"{index:06d}.png")
     cv2.imwrite(filename, frames)
     center_y, center_x = (opts.IM_HEIGHT // 2, opts.IM_WIDTH // 2)
 
@@ -72,14 +76,14 @@ def save_example(example, index, data_paths):
         np.savetxt(filename, depth, fmt="%3.5f")
         mean_depth = depth[center_y - 10:center_y + 10, center_x - 10:center_x + 10].mean()
 
-    filename = op.join(snippet_path, "intrinsic.txt")
+    filename = op.join(image_path, "intrinsic.txt")
     if not op.isfile(filename):
         intrinsic = example["intrinsic"]
         print("intrinsic parameters\n", intrinsic)
         np.savetxt(filename, intrinsic, fmt="%3.5f")
 
     if "stereo_T_LR" in example:
-        filename = op.join(snippet_path, "stereo_T_LR.txt")
+        filename = op.join(image_path, "stereo_T_LR.txt")
         if not op.isfile(filename):
             extrinsic = example["stereo_T_LR"]
             np.savetxt(filename, extrinsic, fmt="%3.5f")
@@ -89,6 +93,7 @@ def save_example(example, index, data_paths):
     return mean_depth
 
 
+# TODO: 이거 지우고 loader에서 가져와
 def get_destination_paths(dstpath, dataset, drive, pose_avail, depth_avail):
     if dataset == "kitti_raw":
         drive_path = op.join(dstpath, f"{drive[0]}_{drive[1]}")
@@ -158,4 +163,4 @@ def copy_text(imgfile, srcpath, dstpath, filename):
 
 if __name__ == "__main__":
     np.set_printoptions(precision=3, suppress=True)
-    prepare_kitti_data("kitti_odom", "val")
+    prepare_kitti_data()

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -7,7 +7,7 @@ import glob
 
 import settings
 from config import opts, get_raw_data_path
-from prepare_data.kitti_loader import dataset_loader_factory
+from prepare_data.example_maker import dataset_loader_factory
 from utils.util_funcs import print_progress_status
 from utils.util_class import PathManager
 
@@ -49,8 +49,6 @@ def prepare_and_save_snippets(snippet_maker, data_reader, dataset, split):
                 example = snippet_maker.get_example(index)
                 mean_depth = save_example(example, index, data_paths)
                 print_progress_status(f"Progress: mean depth={mean_depth:0.3f}, index={index}, {k}/{num_frames}")
-                if k > 5:
-                    break
             # if set_ok() was NOT excuted, the generated path is removed
             pm.set_ok()
         print("")
@@ -91,20 +89,6 @@ def save_example(example, index, data_paths):
     # cv2.imshow("example frames", frames)
     # cv2.waitKey(1)
     return mean_depth
-
-
-# TODO: 이거 지우고 loader에서 가져와
-def get_destination_paths(dstpath, dataset, drive, pose_avail, depth_avail):
-    if dataset == "kitti_raw":
-        drive_path = op.join(dstpath, f"{drive[0]}_{drive[1]}")
-    elif dataset == "kitti_odom":
-        drive_path = op.join(dstpath, drive)
-    else:
-        raise ValueError()
-
-    pose_path = op.join(drive_path, "pose") if pose_avail else None
-    depth_path = op.join(drive_path, "depth") if depth_avail else None
-    return drive_path, pose_path, depth_path
 
 
 def create_validation_set(dataset, src_split):


### PR DESCRIPTION
kitti_loader 내부에서만 kitti_reader가 사용됐는데 그렇게 하니 
prepare_data_main.py 에서부터 kitti_reader 까지 직접 접근 못하고 kitti_loader를 거쳐야해서 불편했다.
여기서는 prepare_data_main.py 에서 kitti_reader를 직접 사용하고
kitti_loader에 kitti_reader를 주입하였다.

reader, loader 두 가지 이름이 헷갈려서 
KittiDataLoader -> ExampleMaker 이렇게 이름을 바꿧다.
