### PR TITLE
Train flownet

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -49,14 +49,15 @@ class VodeOptions:
     LEARNING_RATE = 0.0001
     ENABLE_SHAPE_DECOR = False
     LOG_LOSS = True
-    TRAIN_MODE = ["eager", "graph", "distributed"][2]
+    TRAIN_MODE = ["eager", "graph", "distributed"][1]
     DATASET_TO_USE = ["kitti_raw", "kitti_odom"][0]
     STEREO_EXTRINSIC = True
     SSIM_RATIO = 0.8
-    LOSS_WEIGHTS = {"L1": (1. - SSIM_RATIO)*1., "SSIM": SSIM_RATIO*0.5, "smoothe": 1.,
-                    "L1_R": (1. - SSIM_RATIO)*1., "SSIM_R": SSIM_RATIO*0.5, "smoothe_R": 1.,
+    LOSS_WEIGHTS = {"L1": (1. - SSIM_RATIO) * 1., "SSIM": SSIM_RATIO * 0.5, "smoothe": 1.,
+                    "L1_R": (1. - SSIM_RATIO) * 1., "SSIM_R": SSIM_RATIO * 0.5, "smoothe_R": 1.,
+                    "FW_L1": (1. - SSIM_RATIO) * 1., "FW_SSIM": SSIM_RATIO * 0.5,
+                    "FW_L1_R": (1. - SSIM_RATIO) * 1., "FW_SSIM_R": SSIM_RATIO * 0.5,
                     "stereo_L1": 0.04, "stereo_pose": 0.5}
-    # SYNTHESIZER = "SynthesizeMultiScale"
     OPTIMIZER = ["adam_constant"][0]
     DEPTH_ACTIVATION = ["InverseSigmoid", "Exponential"][0]
     PRETRAINED_WEIGHT = True
@@ -66,7 +67,7 @@ class VodeOptions:
     """
     NET_NAMES = {"depth": "NASNetMobile",
                  "camera": "PoseNet",
-                 # "flow": "PWCNet"
+                 "flow": "PWCNet"
                  }
     DEPTH_CONV_ARGS = {"activation": "leaky_relu", "activation_param": 0.1,
                        "kernel_initializer": "truncated_normal", "kernel_initializer_param": 0.025}

--- a/model/build_model/flow_net.py
+++ b/model/build_model/flow_net.py
@@ -36,12 +36,12 @@ class PWCNet:
         flow2, flow_feat2         = self.upconv_flow(2, c2l, c2r, 5.0,   up_flow3, up_feat3, up=False)
 
         flow2 = self.context_network(flow_feat2, flow2)
-        flows_ms = [flow2, flow3, flow4, flow5, flow6]
+        flow_ms = [flow2, flow3, flow4, flow5]
 
         # reshape back to normal bactch size
         # -> list of [batch, num_src, height//scale, width//scale, channel]
-        flows_ms = self.reshape_batch_back(flows_ms)
-        pwcnet = tf.keras.Model(inputs=input_tensor, outputs={"flows_ms": flows_ms}, name="PWCNet")
+        flow_ms = self.reshape_batch_back(flow_ms)
+        pwcnet = tf.keras.Model(inputs=input_tensor, outputs={"flow_ms": flow_ms}, name="PWCNet")
         return pwcnet
 
     def split_target_and_sources(self, input_tensor):

--- a/model/build_model/flow_net.py
+++ b/model/build_model/flow_net.py
@@ -54,6 +54,7 @@ class PWCNet:
         numsrc = snippet - 1
         target = input_tensor[:, numsrc*height:]
         sources = input_tensor[:, :numsrc*height]
+        print("sources shape", sources.shape, (batch, numsrc, height, width, channel))
         sources = tf.reshape(sources, (batch*numsrc, height, width, channel))
         return target, sources
 
@@ -334,12 +335,12 @@ def run_net(net, input_tensor):
 
 
 if __name__ == "__main__":
-    # test_correlation()
+    test_correlation()
     # test_warp_simple()
     # test_warp_multiple()
     # test_conv2d_5dtensor()
     # test_layer_input()
     # test_reshape_tensor()
     # test_lambda_layer()
-    test_pwcnet()
+    # test_pwcnet()
 

--- a/model/build_model/model_wrappers.py
+++ b/model/build_model/model_wrappers.py
@@ -122,9 +122,7 @@ class StereoPoseModelWrapper(ModelWrapper):
     def __call__(self, features):
         predictions = dict()
         for netname, model in self.models.items():
-            print("predict", netname)
             pred = model(features["image"])
-            print("predict", pred.keys())
             predictions.update(pred)
             preds_right = model(features["image_R"])
             preds_right = {key + "_R": value for key, value in preds_right.items()}

--- a/model/build_model/model_wrappers.py
+++ b/model/build_model/model_wrappers.py
@@ -90,8 +90,8 @@ class ModelWrapper:
 
 
 class StereoModelWrapper(ModelWrapper):
-    def __init__(self, model):
-        super().__init__(model)
+    def __init__(self, models):
+        super().__init__(models)
 
     def __call__(self, features):
         predictions = dict()
@@ -116,18 +116,21 @@ class StereoModelWrapper(ModelWrapper):
 
 
 class StereoPoseModelWrapper(ModelWrapper):
-    def __init__(self, model):
-        super().__init__(model)
+    def __init__(self, models):
+        super().__init__(models)
 
     def __call__(self, features):
         predictions = dict()
         for netname, model in self.models.items():
+            print("predict", netname)
             pred = model(features["image"])
+            print("predict", pred.keys())
             predictions.update(pred)
             preds_right = model(features["image_R"])
             preds_right = {key + "_R": value for key, value in preds_right.items()}
             predictions.update(preds_right)
 
+        print("!!! stereo wrapper model prediction keys:", predictions.keys())
         if "depth_ms" in predictions:
             predictions["disp_ms"] = uf.safe_reciprocal_number_ms(predictions["depth_ms"])
         if "depth_ms_R" in predictions:

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -3,23 +3,26 @@ import model.loss_and_metric.losses as lm
 
 
 def loss_factory(loss_weights=opts.LOSS_WEIGHTS, stereo=opts.STEREO):
-    losses = []
-    weights = []
-    loss_box = {"L1": lm.PhotometricLossMultiScale("L1"),
-                "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
-                "SSIM": lm.PhotometricLossMultiScale("SSIM"),
-                "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
-                "smoothe": lm.SmoothenessLossMultiScale(),
-                "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
-                "stereo_L1": lm.StereoDepthLoss("L1"),
-                "stereo_pose": lm.StereoPoseLoss(),
+    loss_pool = {"L1": lm.PhotometricLossMultiScale("L1"),
+                 "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
+                 "SSIM": lm.PhotometricLossMultiScale("SSIM"),
+                 "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
+                 "FW_L1": lm.FlowWarpLossMultiScale("L1"),
+                 "FW_L1_R": lm.FlowWarpLossMultiScale("L1", key_suffix="_R"),
+                 "FW_SSIM": lm.FlowWarpLossMultiScale("SSIM"),
+                 "FW_SSIM_R": lm.FlowWarpLossMultiScale("SSIM", key_suffix="_R"),
+                 "smoothe": lm.SmoothenessLossMultiScale(),
+                 "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
+                 "stereo_L1": lm.StereoDepthLoss("L1"),
+                 "stereo_pose": lm.StereoPoseLoss(),
                 }
 
+    losses = []
+    weights = []
     for name, loss_w in loss_weights.items():
         if loss_w == 0.:
             continue
-
-        losses.append(loss_box[name])
+        losses.append(loss_pool[name])
         weights.append(loss_w)
 
     return lm.TotalLoss(losses, weights, stereo)

--- a/model/loss_and_metric/loss_util.py
+++ b/model/loss_and_metric/loss_util.py
@@ -1,0 +1,70 @@
+import tensorflow as tf
+from utils.decorators import shape_check
+
+
+@shape_check
+def photometric_loss_l1(synt_target, orig_target):
+    """
+    :param synt_target: scaled synthesized target image [batch, num_src, height/scale, width/scale, 3]
+    :param orig_target: scaled original target image [batch, height/scale, width/scale, 3]
+    :return: photo_loss [batch, num_src]
+    """
+    orig_target = tf.expand_dims(orig_target, axis=1)
+    # create mask to ignore black region
+    synt_target_gray = tf.reduce_mean(synt_target, axis=-1, keepdims=True)
+    error_mask = tf.equal(synt_target_gray, 0)
+
+    # orig_target: [batch, 1, height/scale, width/scale, 3]
+    # axis=1 broadcasted in subtraction
+    # photo_error: [batch, num_src, height/scale, width/scale, 3]
+    photo_error = tf.abs(synt_target - orig_target)
+    photo_error = tf.where(error_mask, tf.constant(0, dtype=tf.float32), photo_error)
+    # average over image dimensions (h, w, c)
+    photo_loss = tf.reduce_mean(photo_error, axis=[2, 3, 4])
+    return photo_loss
+
+
+@shape_check
+def photometric_loss_ssim(synt_target, orig_target):
+    """
+    :param synt_target: scaled synthesized target image [batch, num_src, height/scale, width/scale, 3]
+    :param orig_target: scaled original target image [batch, height/scale, width/scale, 3]
+    :return: photo_loss [batch, num_src]
+    """
+    num_src = synt_target.get_shape().as_list()[1]
+    orig_target = tf.expand_dims(orig_target, axis=1)
+    orig_target = tf.tile(orig_target, [1, num_src, 1, 1, 1])
+    # create mask to ignore black region
+    synt_target_gray = tf.reduce_mean(synt_target, axis=-1, keepdims=True)
+    error_mask = tf.equal(synt_target_gray, 0)
+
+    x = orig_target     # [batch, num_src, height/scale, width/scale, 3]
+    y = synt_target     # [batch, num_src, height/scale, width/scale, 3]
+    c1 = 0.01 ** 2
+    c2 = 0.03 ** 2
+    ksize = [1, 3, 3]
+
+    # TODO IMPORTANT!
+    #   tf.nn.avg_pool results in error like ['NoneType' object has no attribute 'decode']
+    #   when training model with gradient tape in eager mode,
+    #   but no error in graph mode by @tf.function
+    #   Instead, tf.keras.layers.AveragePooling3D results in NO error in BOTH modes
+    # mu_x, mu_y: [batch, num_src, height/scale, width/scale, 3]
+    average_pool = tf.keras.layers.AveragePooling3D(pool_size=ksize, strides=1, padding="SAME")
+    mu_x = average_pool(x)
+    mu_y = average_pool(y)
+    # mu_x = tf.nn.avg_pool(x, ksize=ksize, strides=1, padding='SAME')
+    # mu_y = tf.nn.avg_pool(y, ksize=ksize, strides=1, padding='SAME')
+
+    sigma_x = average_pool(x ** 2) - mu_x ** 2
+    sigma_y = average_pool(y ** 2) - mu_y ** 2
+    sigma_xy = average_pool(x * y) - mu_x * mu_y
+
+    ssim_n = (2 * mu_x * mu_y + c1) * (2 * sigma_xy + c2)
+    ssim_d = (mu_x ** 2 + mu_y ** 2 + c1) * (sigma_x + sigma_y + c2)
+    ssim = ssim_n / ssim_d
+    ssim = tf.clip_by_value((1 - ssim) / 2, 0, 1)
+    ssim = tf.where(error_mask, tf.constant(0, dtype=tf.float32), ssim)
+    # average over image dimensions (h, w, c)
+    ssim = tf.reduce_mean(ssim, axis=[2, 3, 4])
+    return ssim

--- a/model/loss_and_metric/test_loss.py
+++ b/model/loss_and_metric/test_loss.py
@@ -40,7 +40,7 @@ def test_photometric_loss_quality(suffix=""):
         source_image, target_image = uf.split_into_source_and_target(stacked_image)
         depth_gt_ms = uf.multi_scale_depths(depth_gt, [1, 2, 4, 8])
         pose_gt = cp.pose_matr2rvec_batch(pose_gt)
-        target_ms = uf.multi_scale_like(target_image, depth_gt_ms)
+        target_ms = uf.multi_scale_like_depth(target_image, depth_gt_ms)
         batch, height, width, _ = target_image.get_shape().as_list()
 
         synth_target_ms = SynthesizeMultiScale()(source_image, intrinsic, depth_gt_ms, pose_gt)
@@ -94,7 +94,7 @@ def test_photometric_loss_quantity(suffix=""):
         source_image, target_image = uf.split_into_source_and_target(stacked_image)
         depth_gt_ms = uf.multi_scale_depths(depth_gt, [1, 2, 4, 8])
         pose_gt = cp.pose_matr2rvec_batch(pose_gt)
-        target_ms = uf.multi_scale_like(target_image, depth_gt_ms)
+        target_ms = uf.multi_scale_like_depth(target_image, depth_gt_ms)
 
         # EXECUTE
         batch_loss_right, scale_loss_right, recon_image_right = \
@@ -219,7 +219,7 @@ def test_smootheness_loss_quantity():
 def tu_smootheness_loss(depth_gt, target_image):
     depth_gt_ms = uf.multi_scale_depths(depth_gt, [1, 2, 4, 8])
     disp_gt_ms = uf.safe_reciprocal_number_ms(depth_gt_ms)
-    target_ms = uf.multi_scale_like(target_image, depth_gt_ms)
+    target_ms = uf.multi_scale_like_depth(target_image, depth_gt_ms)
 
     features = {"image": target_image}
     predictions = {"disp_ms": disp_gt_ms}

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -34,7 +34,6 @@ def train(final_epoch=opts.EPOCHS):
     print(f"\n\n========== START TRAINING ON {opts.CKPT_NAME} ==========")
     for epoch in range(initial_epoch, final_epoch):
         print(f"========== Start epoch: {epoch}/{final_epoch} ==========")
-
         result_train, depth_train = trainer.run_an_epoch(dataset_train)
         result_val, depth_val = validater.run_an_epoch(dataset_val)
 
@@ -167,7 +166,7 @@ def test_model_wrapper_output():
 
 if __name__ == "__main__":
     reset_period = 15
-    for epoch in range(reset_period, opts.EPOCHS, reset_period):
-        train(epoch)
+    for epoch_ in range(reset_period, opts.EPOCHS, reset_period):
+        train(epoch_)
     # predict()
     # test_model_wrapper_output()

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -233,7 +233,7 @@ def copy_or_check_same():
                  not callable(getattr(CurrOptions, attr)) and not attr.startswith('__')}
 
     dont_care_opts = ["BATCH_SIZE", "EPOCHS", "LEARNING_RATE", "ENABLE_SHAPE_DECOR",
-                      "CKPT_NAME", "LOG_LOSS", "PROJECT_ROOT", "DATASET", "TRAIN_MODE"]
+                      "CKPT_NAME", "LOG_LOSS", "PROJECT_ROOT", "DATASET", "TRAIN_MODE", "LOSS_WEIGHTS"]
 
     for key, saved_val in saved_opts.items():
         if key in dont_care_opts:

--- a/model/synthesize/flow_warping.py
+++ b/model/synthesize/flow_warping.py
@@ -1,0 +1,120 @@
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras import layers
+import tensorflow_addons as tfa
+
+from config import opts
+from utils.decorators import shape_check
+
+
+class FlowWarpMultiScale:
+    @shape_check
+    def __call__(self, src_img_stacked, flow_ms):
+        """
+        :param src_img_stacked: source images stacked vertically [batch, height*num_src, width, 3]
+        :param flow_ms: predicted optical flow from source to target in multi scale,
+                        list of [batch, num_src, height/scale, width/scale, 1] (scale: 1, 2, 4, 8)
+        :return: reconstructed target view in multi scale, list of [batch, num_src, height/scale, width/scale, 3]}
+        """
+        warped_targets = []
+        for flow_sc in flow_ms:
+            # construct a new graph for each scale
+            warp_target_sc = FlowWarpSingleScale()(src_img_stacked, flow_sc)
+            warped_targets.append(warp_target_sc)
+        return warped_targets
+
+
+class FlowWarpSingleScale:
+    def __init__(self):
+        # shape is scaled from the original shape, height = original_height / scale
+        self.batch, self.height, self.width, self.num_src, self.scale = (0, 0, 0, 0, 0)
+        self.suffix = ""
+
+    def __call__(self, src_img_stacked, flow_sc):
+        """
+        :param src_img_stacked: stacked source images [batch, height*num_src, width, 3]
+        :param flow_sc: scaled predicted optical flow for target image, [batch, num_src, height/scale, width/scale, 1]
+        :return: warped target view in scale, [batch, num_src, height/scale, width/scale, 3]
+        """
+        self.read_shape(src_img_stacked, flow_sc)
+        # resize and reshape source images -> [batch*num_src, height/scale, width/scale, 3]
+        src_img_scaled = layers.Lambda(lambda image: self.reshape_source_images(image),
+                                       name=f"flow_reorder_src" + self.suffix)(src_img_stacked)
+        warped_image = self.warp_image(src_img_scaled, flow_sc)
+        return warped_image
+
+    @shape_check
+    def read_shape(self, src_img_stacked, flow_sc):
+        batch_size, stacked_height, width_orig, _ = src_img_stacked.get_shape()
+        self.batch, self.num_src, self.height, self.width, _ = flow_sc.get_shape()
+        self.scale = int(width_orig / self.width)
+        self.suffix = f"_sc{self.scale}"
+
+    @shape_check
+    def reshape_source_images(self, src_img_stacked):
+        """
+        :param src_img_stacked: [batch, height*num_src, width, 3]
+        :return: reorganized source images [batch, num_src, height/scale, width/scale, 3]
+        """
+        batch_size, stacked_height, width_orig, _ = src_img_stacked.get_shape()
+        height_orig = stacked_height // self.num_src
+        # reshape image -> (batch*num_src, height_orig, width_orig, 3)
+        source_images = tf.reshape(src_img_stacked, shape=(self.batch * self.num_src, height_orig, width_orig, 3))
+        # resize image (scaled) -> (batch*num_src, height, width, 3)
+        scaled_image = tf.image.resize(source_images, size=(self.height, self.width), method="bilinear")
+        return scaled_image
+
+    def warp_image(self, src_img, flow_sc):
+        """
+        :param src_img: reorganized source images [batch*num_src, height/scale, width/scale, 3]
+        :param flow_sc: optical flow [batch, num_src, height/scale, width/sclae, 2]
+        :return:
+        """
+        # reshape flow -> [batch*num_src, height/scale, width/scale, 2]
+        flow_reshaped = tf.reshape(flow_sc, (self.batch * self.num_src, self.height, self.width, 2))
+        # warped target view from source images -> [batch*num_src, height/scale, width/scale, 3]
+        warped_image = tfa.image.dense_image_warp(src_img, flow_reshaped, name=f"warped" + self.suffix)
+        # reshape warped image-> [batch, num_src, height/scale, width/scale, 3]
+        warped_image = tf.reshape(warped_image, (self.batch, self.num_src, self.height, self.width, 3))
+        return warped_image
+
+
+# ==================================================
+import os.path as op
+import cv2
+
+
+def test_reshape_source_images():
+    print("===== start test_reshape_source_images")
+    opts.ENABLE_SHAPE_DECOR = True
+    image_path = op.join(opts.DATAPATH_SRC, "kitti_odom_train", "11", "000002.png")
+    src_img = cv2.imread(image_path)
+    cv2.imshow("src_img", src_img)
+    cv2.waitKey(10)
+    bat_img = tf.constant([src_img, src_img, src_img], dtype=tf.float32)
+    print("src_img shape", bat_img.shape)
+
+    # take only left image
+    left_img = bat_img[:, :, :opts.IM_WIDTH]
+    print("left_img shape", left_img.shape)
+    cv2.imshow("left_img", left_img[0].numpy().astype(np.uint8))
+    cv2.waitKey(10)
+
+    # reshape image
+    batch = 3
+    num_src = 5
+    height, width = opts.IM_HEIGHT, opts.IM_WIDTH
+
+    # EXECUTE
+    rsp_img = tf.reshape(left_img, (batch*num_src, height, width, 3))
+
+    print("rsp_img shape", rsp_img.shape)
+    assert np.isclose(rsp_img[1].numpy(), src_img[height:height*2, :width]).all()
+    print("!!! test_reshape_source_images passed")
+
+    cv2.imshow("rsp_img", rsp_img[0].numpy().astype(np.uint8))
+    cv2.waitKey(0)
+
+
+if __name__ == "__main__":
+    test_reshape_source_images()

--- a/model/synthesize/synthesize_base.py
+++ b/model/synthesize/synthesize_base.py
@@ -77,9 +77,13 @@ class SynthesizeBatchBasic:
         :param src_img_stacked: [batch, height*num_src, width, 3]
         :return: reorganized source images [batch, num_src, height/scale, width/scale, 3]
         """
-        # resize image
-        scaled_image = tf.image.resize(src_img_stacked, size=(self.height * self.num_src, self.width), method="bilinear")
-        # reorganize scaled images: (4*height/scale,) -> (4, height/scale)
+        batch_size, stacked_height, width_orig, _ = src_img_stacked.get_shape()
+        height_orig = stacked_height // self.num_src
+        # reshape image -> (batch*num_src, height_orig, width_orig, 3)
+        source_images = tf.reshape(src_img_stacked, shape=(self.batch * self.num_src, height_orig, width_orig, 3))
+        # resize image (scaled) -> (batch*num_src, height, width, 3)
+        scaled_image = tf.image.resize(source_images, size=(self.height, self.width), method="bilinear")
+        # reorganize scaled images -> (batch, num_src, height, width, 3)
         source_images = tf.reshape(scaled_image, shape=(self.batch, self.num_src, self.height, self.width, 3))
         return source_images
 

--- a/model/train_val.py
+++ b/model/train_val.py
@@ -68,12 +68,15 @@ class ModelTrainer(TrainValBase):
         super().__init__("Train (graph)", model, loss_object, steps_per_epoch, stereo, optimizer)
 
     def run_a_batch(self, features):
+        print("----- run_a_batch")
         return self.train_a_step(features)
 
     def train_a_step(self, features):
         with tf.GradientTape() as tape:
             # NOTE! preds = {"depth_ms": ..., "pose": ...} = model(image)
+            print("----- model(features)")
             preds = self.model(features)
+            print("----- model(features) done")
             loss_batch, loss_by_type = self.loss_object(preds, features)
 
         grads = tape.gradient(loss_batch, self.model.trainable_weights())
@@ -94,6 +97,7 @@ class ModelTrainerGraph(ModelTrainer):
 
     @tf.function
     def run_a_batch(self, features):
+        print("======== run_a_batch22")
         return self.train_a_step(features)
 
 

--- a/model/train_val.py
+++ b/model/train_val.py
@@ -68,15 +68,12 @@ class ModelTrainer(TrainValBase):
         super().__init__("Train (graph)", model, loss_object, steps_per_epoch, stereo, optimizer)
 
     def run_a_batch(self, features):
-        print("----- run_a_batch")
         return self.train_a_step(features)
 
     def train_a_step(self, features):
         with tf.GradientTape() as tape:
             # NOTE! preds = {"depth_ms": ..., "pose": ...} = model(image)
-            print("----- model(features)")
             preds = self.model(features)
-            print("----- model(features) done")
             loss_batch, loss_by_type = self.loss_object(preds, features)
 
         grads = tape.gradient(loss_batch, self.model.trainable_weights())
@@ -97,7 +94,6 @@ class ModelTrainerGraph(ModelTrainer):
 
     @tf.function
     def run_a_batch(self, features):
-        print("======== run_a_batch22")
         return self.train_a_step(features)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ six==1.13.0
 tensorboard==2.2.2
 tensorboard-plugin-wit==1.7.0
 tensorflow==2.2.0
-tensorflow-addons==0.8.3
+tensorflow-addons==0.10.0
 tensorflow-estimator==2.2.0
 tensorflow-gpu==2.0.0
 termcolor==1.1.0

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -21,7 +21,7 @@ def convert_to_tfrecords():
         else:
             with PathManager([tfrpath]) as pm:
                 os.makedirs(tfrpath, exist_ok=True)
-                tfrmaker = TfrecordMaker(srcpath, tfrpath, opts.STEREO, opts.IM_WIDTH)
+                tfrmaker = TfrecordMaker(srcpath, tfrpath, opts.STEREO)
                 tfrmaker.make()
                 # if set_ok() was NOT excuted, the generated path is removed
                 pm.set_ok()

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -158,7 +158,7 @@ def safe_reciprocal_number(src_tensor):
     return dst_tensor
 
 
-def multi_scale_like(image, disp_ms):
+def multi_scale_like_depth(image, disp_ms):
     """
     :param image: [batch, height, width, 3]
     :param disp_ms: list of [batch, height/scale, width/scale, 1]
@@ -168,7 +168,22 @@ def multi_scale_like(image, disp_ms):
     for i, disp in enumerate(disp_ms):
         batch, height_sc, width_sc, _ = disp.get_shape().as_list()
         image_sc = layers.Lambda(lambda img: tf.image.resize(img, size=(height_sc, width_sc), method="bilinear"),
-                                 name=f"target_resize_{i}")(image)
+                                 name=f"resize_like_depth_{i}")(image)
+        image_ms.append(image_sc)
+    return image_ms
+
+
+def multi_scale_like_flow(image, flow_ms):
+    """
+    :param image: [batch, height, width, 3]
+    :param flow_ms: list of [batch, num_src, height/scale, width/scale, 1]
+    :return: image_ms: list of [batch, height/scale, width/scale, 3]
+    """
+    image_ms = []
+    for i, flow in enumerate(flow_ms):
+        batch, num_src, height_sc, width_sc, _ = flow.get_shape().as_list()
+        image_sc = layers.Lambda(lambda img: tf.image.resize(img, size=(height_sc, width_sc), method="bilinear"),
+                                 name=f"resize_like_flow_{i}")(image)
         image_ms.append(image_sc)
     return image_ms
 


### PR DESCRIPTION
## flownet 학습 기능 구현

### losses.py

`TotalLoss.augment_data()`에서 `FlowWarpMultiScale` 클래스 이용하여 이미지 합성
`FlowWarpLossMultiScale` 클래스에서 multi scale flow로 합성한 이미지와 원래 이미지 사이 차이 계산

### model/systhesize/flow_warping.py

`FlowWarpMultiScale`, `FlowWarpSingleScale` 클래스 구현
`tfa.image.dense_image_warp()` 함수를 이용하여 이미지 합성

### config.py

flow warping 관련 loss 추가
```python
LOSS_WEIGHTS = {"L1": (1. - SSIM_RATIO) * 1., "SSIM": SSIM_RATIO * 0.5, "smoothe": 1.,
                "L1_R": (1. - SSIM_RATIO) * 1., "SSIM_R": SSIM_RATIO * 0.5, "smoothe_R": 1.,
                "FW_L1": (1. - SSIM_RATIO) * 1., "FW_SSIM": SSIM_RATIO * 0.5,
                "FW_L1_R": (1. - SSIM_RATIO) * 1., "FW_SSIM_R": SSIM_RATIO * 0.5,
                "stereo_L1": 0.04, "stereo_pose": 0.5}
```

### loss_factory.py

loss_factory()에 config.py에서 추가한 loss key에 따라 loss 객체 생성해서 입력
```python
loss_pool = {...
             "FW_L1": lm.FlowWarpLossMultiScale("L1"),
             "FW_L1_R": lm.FlowWarpLossMultiScale("L1", key_suffix="_R"),
             "FW_SSIM": lm.FlowWarpLossMultiScale("SSIM"),
             "FW_SSIM_R": lm.FlowWarpLossMultiScale("SSIM", key_suffix="_R"),
```

### flownet.py

`tfa.layers.CorrelationCost()` 파라미터 조절
feature 해상도에 따라 optical flow가 최대로 움직일 수 있는 `max_displacement`를 조절해야 함
`max_displacement(md)`에 따라 correlation volume의 채널 수가 
`(2*md+1)^2` 이 되므로 out of memory 에러 발생
이를 방지하기 위해 `stride_2 = max_displacement // 4`로 맞춰서 출력 채널수를 일정하게 맞춤
현재는 correlation으로 주로 81 채널이 출력됨
