### PR TITLE
save flow reconstruction image

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -7,7 +7,7 @@ RAW_DATA_PATHS = {
     "cityscapes": "/media/ian/IanPrivatePP/Datasets/cityscapes",
     "cityscapes_seq": "/media/ian/IanPrivatePP/Datasets/cityscapes",
 }
-RESULT_DATAPATH = "/media/ian/IanPrivatePP/Datasets/vode_data/vode_stereo_0705"
+RESULT_DATAPATH = "/home/ian/workspace/vode/vode-data"
 
 
 class VodeOptions:
@@ -27,8 +27,8 @@ class VodeOptions:
                            # "cityscapes_seq": ["train"],
                            }
     # only when making small tfrecords to test training
-    LIMIT_FRAMES = None
-    SHUFFLE_TFRECORD_INPUT = False
+    LIMIT_FRAMES = 200
+    SHUFFLE_TFRECORD_INPUT = True
 
     """
     path options
@@ -46,23 +46,24 @@ class VodeOptions:
     """
     training options
     """
-    CKPT_NAME = "vode2"
+    CKPT_NAME = "vode5"
     PER_REPLICA_BATCH = 4
     BATCH_SIZE = PER_REPLICA_BATCH
     EPOCHS = 51
     LEARNING_RATE = 0.0001
     ENABLE_SHAPE_DECOR = False
     LOG_LOSS = True
-    TRAIN_MODE = ["eager", "graph", "distributed"][2]
+    TRAIN_MODE = ["eager", "graph", "distributed"][1]
     DATASET_TO_USE = ["kitti_raw", "kitti_odom"][0]
     STEREO_EXTRINSIC = True
     SSIM_RATIO = 0.8
-    LOSS_WEIGHTS = {"L1": (1. - SSIM_RATIO) * 1., "SSIM": SSIM_RATIO * 0.5, "smoothe": 1.,
-                    "L1_R": (1. - SSIM_RATIO) * 1., "SSIM_R": SSIM_RATIO * 0.5, "smoothe_R": 1.,
-                    "stereo_L1": 0.01, "stereo_pose": 0.5,
-                    "FW_L2": 1.,
-                    "FW_L2_R": 1.,
-                    "FW_L2_regular": 0.0004
+    LOSS_WEIGHTS = {"L1": (1. - SSIM_RATIO) * 1., "L1_R": (1. - SSIM_RATIO) * 1.,
+                    "SSIM": SSIM_RATIO * 0.5, "SSIM_R": SSIM_RATIO * 0.5,
+                    "smoothe": 1., "smoothe_R": 1.,
+                    "stereo_L1": 0.01, "stereo_SSIM": 0.01,
+                    "stereo_pose": 1.,
+                    "flow_L2": 1., "flow_L2_R": 1.,
+                    "flow_L2_reg": 4e-7
                     }
     OPTIMIZER = ["adam_constant"][0]
     DEPTH_ACTIVATION = ["InverseSigmoid", "Exponential"][0]

--- a/model/build_model/depth_net.py
+++ b/model/build_model/depth_net.py
@@ -63,7 +63,7 @@ class DepthNetBasic:
         depth0, dpconvn1_up, dpconv0 = self.get_scaled_depth(upconv0, height, width, "dp_depth0")
 
         outputs = {"depth_ms": [depth0, depth1, depth2, depth3],
-                   "debug_out": [dpconv0, upconv0, dpconv3, upconv3]}
+                   "debug_out": [upconv0, upconv3]}
         depthnet = tf.keras.Model(inputs=input_tensor, outputs=outputs, name="depthnet")
         return depthnet
 

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -13,6 +13,7 @@ def loss_factory(loss_weights=opts.LOSS_WEIGHTS, stereo=opts.STEREO,
                  "smoothe": lm.SmoothenessLossMultiScale(),
                  "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
                  "stereo_L1": lm.StereoDepthLoss("L1"),
+                 "stereo_SSIM": lm.StereoDepthLoss("SSIM"),
                  "stereo_pose": lm.StereoPoseLoss(),
                  "FW_L2_regular": lm.L2Regularizer(weights_to_regularize),
                  }

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -8,14 +8,14 @@ def loss_factory(loss_weights=opts.LOSS_WEIGHTS, stereo=opts.STEREO,
                  "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
                  "SSIM": lm.PhotometricLossMultiScale("SSIM"),
                  "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
-                 "FW_L2": lm.FlowWarpLossMultiScale("L2"),
-                 "FW_L2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
+                 "flow_L2": lm.FlowWarpLossMultiScale("L2"),
+                 "flow_L2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
                  "smoothe": lm.SmoothenessLossMultiScale(),
                  "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
                  "stereo_L1": lm.StereoDepthLoss("L1"),
                  "stereo_SSIM": lm.StereoDepthLoss("SSIM"),
                  "stereo_pose": lm.StereoPoseLoss(),
-                 "FW_L2_regular": lm.L2Regularizer(weights_to_regularize),
+                 "flow_L2_reg": lm.L2Regularizer(weights_to_regularize),
                  }
 
     losses = dict()

--- a/model/loss_and_metric/losses.py
+++ b/model/loss_and_metric/losses.py
@@ -91,6 +91,7 @@ class TotalLoss:
         # warped image is used in both L1 and SSIM photometric losses
         if "flow_ms" + suffix in predictions:
             pred_flow_ms = predictions["flow_ms" + suffix]
+            # flows have lower resolution than depths, so "target_ms" is not appropriate for flows
             flow_target_ms = uf.multi_scale_like_flow(target_image, pred_flow_ms)
             augm_data["flow_target_ms" + suffix] = flow_target_ms
             warped_target_ms = FlowWarpMultiScale()(source_image, pred_flow_ms)

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -38,8 +38,7 @@ def train(final_epoch=opts.EPOCHS):
         result_val = validater.run_an_epoch(dataset_val)
 
         print("save intermediate results ...")
-        log.save_reconstruction_samples(model, dataset_val, epoch)
-        # log.save_loss_scales(model, dataset_val, val_steps, opts.STEREO)
+        log.save_reconstruction_samples(model, dataset_val, val_steps, epoch)
         save_model(model, result_val)
         log.save_log(epoch, result_train, result_val)
 

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -87,8 +87,8 @@ def draw_and_save_plot(results, filename):
     plt.close("all")
 
 
-def save_reconstruction_samples(model, dataset, epoch):
-    views = make_reconstructed_views(model, dataset)
+def save_reconstruction_samples(model, dataset, total_steps, epoch):
+    views = make_reconstructed_views(model, dataset, total_steps)
     savepath = op.join(opts.DATAPATH_CKP, opts.CKPT_NAME, 'reconimg')
     if not op.isdir(savepath):
         os.makedirs(savepath, exist_ok=True)
@@ -97,31 +97,29 @@ def save_reconstruction_samples(model, dataset, epoch):
         cv2.imwrite(filename, view)
 
 
-def make_reconstructed_views(model, dataset):
+def make_reconstructed_views(model, dataset, total_steps):
     recon_views = []
-    next_idx = 0
-    stride = 10
-    stereo_loss = lm.StereoDepthLoss("L1")
+    stride = min(total_steps, 200) // 10
+    max_steps = stride * 10
     total_loss = lm.TotalLoss()
     scaleidx, batchidx, srcidx = 0, 0, 0
 
     for i, features in enumerate(dataset):
-        if i < next_idx:
+        if i % stride != 1:
             continue
-        if i // stride > 5:
-            stride *= 10
-        next_idx += stride
+        if i > max_steps:
+            break
 
+        # predict by model
         predictions = model(features)
+
+        # create intermediate data
         augm_data = total_loss.augment_data(features, predictions)
         if opts.STEREO:
             augm_data_rig = total_loss.augment_data(features, predictions, "_R")
             augm_data.update(augm_data_rig)
-
-        synth_target_ms = SynthesizeMultiScale()(src_img_stacked=augm_data["source"],
-                                                 intrinsic=features["intrinsic"],
-                                                 pred_depth_ms=predictions["depth_ms"],
-                                                 pred_pose=predictions["pose"])
+            augm_data_stereo = total_loss.synethesize_stereo(features, predictions, augm_data)
+            augm_data.update(augm_data_stereo)
 
         target_depth = predictions["depth_ms"][0][batchidx]
         target_depth = tf.clip_by_value(target_depth, 0., 20.) / 10. - 1.
@@ -129,24 +127,16 @@ def make_reconstructed_views(model, dataset):
         view_imgs = {"left_target": augm_data["target"][0],
                      "target_depth": target_depth,
                      f"source_{srcidx}": time_source,
-                     f"synthesized_from_src{srcidx}": synth_target_ms[scaleidx][batchidx, srcidx]
+                     f"synthesized_from_src{srcidx}": augm_data["synth_target_ms"][scaleidx][batchidx, srcidx]
                      }
         view_imgs["time_diff"] = tf.abs(view_imgs["left_target"] - view_imgs[f"synthesized_from_src{srcidx}"])
 
         if opts.STEREO:
-            loss_left, synth_left_ms = \
-                stereo_loss.stereo_synthesize_loss(source_img=augm_data["target_R"],
-                                                   target_ms=augm_data["target_ms"],
-                                                   target_depth_ms=predictions["depth_ms"],
-                                                   pose_t2s=tf.linalg.inv(features["stereo_T_LR"]),
-                                                   intrinsic=features["intrinsic"])
-
             # print("stereo synth size", tf.size(synth_left_ms[scaleidx]).numpy())
             # zeromask = tf.cast(tf.math.equal(synth_left_ms[scaleidx], 0.), tf.int32)
             # print("stereo synth zero count", tf.reduce_sum(zeromask).numpy())
-            print(f"saving synthesized image {i}, stereo loss R2L:", tf.squeeze(loss_left[0]).numpy())
             view_imgs["right_source"] = augm_data["target_R"][batchidx]
-            view_imgs["synthesized_from_right"] = synth_left_ms[scaleidx][batchidx, srcidx]
+            view_imgs["synthesized_from_right"] = augm_data["stereo_synth_ms"][scaleidx][batchidx, srcidx]
             view_imgs["stereo_diff"] = tf.abs(view_imgs["left_target"] - view_imgs["synthesized_from_right"])
 
         view1 = uf.stack_titled_images(view_imgs)

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -20,8 +20,9 @@ def save_log(epoch, results_train, results_val):
     :param results_train: dict of losses, metrics and depths from training data
     :param results_val: dict of losses, metrics and depths from validation data
     """
-    summary = save_results(epoch, results_train, results_val, ["loss", "trjerr", "roterr"], "history.csv")
-    other_cols = [colname for colname in results_train.keys() if colname not in ["loss", "trjerr", "roterr"]]
+    summ_cols = ["loss", "trjerr", "roterr"]
+    summary = save_results(epoch, results_train, results_val, summ_cols, "history.csv")
+    other_cols = [colname for colname in results_train.keys() if colname not in summ_cols]
     _ = save_results(epoch, results_train, results_val, other_cols, "mean_result.csv")
 
     save_scales(epoch, results_train, results_val, "scales.txt")
@@ -49,8 +50,9 @@ def save_results(epoch, results_train, results_val, columns, filename):
         results = pd.DataFrame([epoch_result])
 
     # reorder columns
-    loss_cols = list(opts.LOSS_WEIGHTS.keys())
-    other_cols = [col for col in columns if col not in loss_cols]
+    all_loss_cols = list(opts.LOSS_WEIGHTS.keys())
+    loss_cols = [col for col in columns if col in all_loss_cols]
+    other_cols = [col for col in columns if col not in all_loss_cols]
     split_cols = loss_cols + other_cols
     train_cols = ["t_" + col for col in split_cols]
     val_cols = ["v_" + col for col in split_cols]
@@ -58,6 +60,7 @@ def save_results(epoch, results_train, results_val, columns, filename):
     print("total cols", total_cols)
     print("result", list(results))
     results = results.loc[:, total_cols]
+    print("LOG: Results:", results)
 
     # write to a file
     results['epoch'] = results['epoch'].astype(int)

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -144,13 +144,13 @@ def make_reconstructed_views(model, dataset, total_steps):
                      }
         # view_imgs["time_diff"] = tf.abs(view_imgs["left_target"] - view_imgs[f"synthesized_from_src{srcidx}"])
 
+        if "flow_ms" in predictions:
+            view_imgs["synthesized_by_flow"] = augm_data["warped_target_ms"][scaleidx][batchidx, srcidx]
+
         if opts.STEREO:
             view_imgs["right_source"] = augm_data["target_R"][batchidx]
             view_imgs["synthesized_from_right"] = augm_data["stereo_synth_ms"][scaleidx][batchidx, srcidx]
             # view_imgs["stereo_diff"] = tf.abs(view_imgs["left_target"] - view_imgs["synthesized_from_right"])
-
-        if "flow_ms" in predictions:
-            view_imgs["synthesized_by_flow"] = augm_data["warped_target_ms"][scaleidx][batchidx, srcidx]
 
         view1 = uf.stack_titled_images(view_imgs)
         recon_views.append(view1)

--- a/model/synthesize/bilinear_interp.py
+++ b/model/synthesize/bilinear_interp.py
@@ -171,7 +171,6 @@ class FlowBilinearInterpolation:
         :param flow: optical flow [batch*num_src, height, width, 2(u,v)]
         :return: reconstructed image [batch*num_src, height, width, ?]
         """
-        _, height, width, channels = image.get_shape()
         # -> [batch*num_src, 1, height, width, ?]
         feature = tf.expand_dims(image, axis=1)
         flow = tf.expand_dims(flow, axis=1)

--- a/tfrecords/tfrecord_reader.py
+++ b/tfrecords/tfrecord_reader.py
@@ -117,6 +117,7 @@ def test_read_dataset():
         for key, value in x.items():
             print(f"x shape and type: {key}={value.shape}, {value.dtype}")
 
+        print("stereo pose\n", x["stereo_T_LR"][0].numpy())
         print("gt poses:\n", x['pose_gt'].numpy()[0])
         image = tf.image.convert_image_dtype((x["image"] + 1.)/2., dtype=tf.uint8).numpy()
         cv2.imshow("image", image[0])

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -163,15 +163,15 @@ def safe_reciprocal_number(src_tensor):
     return dst_tensor
 
 
-def multi_scale_like_depth(image, disp_ms):
+def multi_scale_like_depth(image, depth_ms):
     """
     :param image: [batch, height, width, 3]
-    :param disp_ms: list of [batch, height/scale, width/scale, 1]
+    :param depth_ms: list of [batch, height/scale, width/scale, 1]
     :return: image_ms: list of [batch, height/scale, width/scale, 3]
     """
     image_ms = []
-    for i, disp in enumerate(disp_ms):
-        batch, height_sc, width_sc, _ = disp.get_shape().as_list()
+    for i, depth in enumerate(depth_ms):
+        batch, height_sc, width_sc, _ = depth.get_shape().as_list()
         image_sc = layers.Lambda(lambda img: tf.image.resize(img, size=(height_sc, width_sc), method="bilinear"),
                                  name=f"resize_like_depth_{i}")(image)
         image_ms.append(image_sc)
@@ -193,7 +193,7 @@ def multi_scale_like_flow(image, flow_ms):
     return image_ms
 
 
-def stack_titled_images(view_imgs):
+def stack_titled_images(view_imgs, guide_lines=True):
     dsize = (opts.IM_HEIGHT, opts.IM_WIDTH)
     location = (20, 20)
     font = cv2.FONT_HERSHEY_SIMPLEX
@@ -211,6 +211,9 @@ def stack_titled_images(view_imgs):
         view.append(u8image)
 
     view = np.concatenate(view, axis=0)
+    if guide_lines:
+        view[:, 100] = (0, 0, 255)
+        view[:, -100] = (0, 0, 255)
     return view
 
 

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -130,10 +130,11 @@ def check_tfrecord_including(dataset_dir, key_list):
 
 
 def read_previous_epoch(model_name):
-    filename = op.join(opts.DATAPATH_CKP, model_name, 'history.txt')
+    filename = op.join(opts.DATAPATH_CKP, model_name, 'history.csv')
     if op.isfile(filename):
         history = pd.read_csv(filename, encoding='utf-8', converters={'epoch': lambda c: int(c)})
         if history.empty:
+            print("[read_previous_epoch] EMPTY history:", history)
             return 0
         epochs = history['epoch'].tolist()
         epochs.sort()
@@ -141,6 +142,7 @@ def read_previous_epoch(model_name):
         print(f"[read_previous_epoch] start from epoch {prev_epoch + 1}")
         return prev_epoch + 1
     else:
+        print("[read_previous_epoch] NO history")
         return 0
 
 


### PR DESCRIPTION
## reconstruction 방법 정리

flownet 내부에서는 `tfa.image.dense_image_warp` 사용
flow photometric loss 계산할 때는 `FlowBlinearInterpolation` 사용


## logging/debugging 개선

### make_reconstructed_views

`StereoDepthLoss`에서 만들던 stereo reconstruction image를 `TotalLoss.synethesize_stereo`에서 만들게 해서
`make_reconstructed_views`에서도 사용
flow reconstruction image도 reconimg에 추가
기존에 있던 "time_diff", "stereo_diff"는 제거
위아래 이미지들을 비교하기 위해 이미지의 양끝에서 100번째 열에 빨간줄 그리기

### save_results

history.txt에서 불필요한 column들 나왔던 것 제거


## 학습 중 print 수정

flow도 10분위 크기 출력
`inspect_model`에서 pose prediction과 pose gt의 translation 부분만 출력
