### PR TITLE
Waymo tfrecords directly

### DIFF
--- a/model/build_model/depth_net.py
+++ b/model/build_model/depth_net.py
@@ -170,7 +170,7 @@ class TempActivation:
 
 
 def test_build_model():
-    total_shape = (opts.BATCH_SIZE, opts.SNIPPET_LEN, opts.IM_HEIGHT, opts.IM_WIDTH, 3)
+    total_shape = opts.get_shape("BSHWC")
     depthnet = DepthNetFromPretrained(total_shape, TempActivation(), "NASNetMobile", True)()
     depthnet.summary()
     depth_ms = depthnet.output["depth_ms"]

--- a/model/build_model/model_factory.py
+++ b/model/build_model/model_factory.py
@@ -12,19 +12,19 @@ import model.model_util.layer_ops as lo
 
 
 PRETRAINED_MODELS = ["MobileNetV2", "NASNetMobile", "DenseNet121", "VGG16", "Xception", "ResNet50V2", "NASNetLarge"]
-DEFAULT_SHAPE = (opts.PER_REPLICA_BATCH, opts.SNIPPET_LEN, opts.IM_HEIGHT, opts.IM_WIDTH, 3)
 
 
 class ModelFactory:
-    def __init__(self, input_shape=DEFAULT_SHAPE,
+    def __init__(self, dataset=opts.DATASET_TO_USE,
                  global_batch=opts.BATCH_SIZE,
                  net_names=opts.NET_NAMES,
                  depth_activation=opts.DEPTH_ACTIVATION,
                  pretrained_weight=opts.PRETRAINED_WEIGHT,
                  stereo=opts.STEREO,
                  stereo_extrinsic=opts.STEREO_EXTRINSIC):
-        self.input_shape = input_shape
         self.global_batch = global_batch
+        S, H, W, C = opts.get_shape("SHWC", dataset)
+        self.input_shape = (global_batch, S, H, W, C)
         self.net_names = net_names
         self.activation = depth_activation
         self.pretrained_weight = pretrained_weight

--- a/model/loss_and_metric/test_loss.py
+++ b/model/loss_and_metric/test_loss.py
@@ -137,7 +137,7 @@ def test_photo_loss(source_image, intrinsic, depth_gt_ms, pose_gt, target_ms):
         losses.append(loss)
         if scale == 1:
             recon_target = uf.to_uint8_image(synt_target).numpy()
-            recon_image = cv2.resize(recon_target[0, 0], (opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_NEAREST)
+            recon_image = cv2.resize(recon_target[0, 0], opts.get_shape("WH"), interpolation=cv2.INTER_NEAREST)
 
     losses = tf.stack(losses, axis=2)   # [batch, numsrc, num_scales]
     batch_loss = tf.reduce_sum(losses, axis=[1, 2])
@@ -180,8 +180,9 @@ def test_smootheness_loss_quantity():
         stacked_image = features["image"]
         depth_gt = features["depth_gt"]
         # interpolate depth
-        depth_gt = tf.image.resize(depth_gt, size=(int(opts.IM_HEIGHT/2), int(opts.IM_WIDTH/2)), method="bilinear")
-        depth_gt = tf.image.resize(depth_gt, size=(opts.IM_HEIGHT, opts.IM_WIDTH), method="bilinear")
+        height, width = opts.get_shape("HW")
+        depth_gt = tf.image.resize(depth_gt, size=(height//2, width//2), method="bilinear")
+        depth_gt = tf.image.resize(depth_gt, size=(height, width), method="bilinear")
         # make multi-scale data
         source_image, target_image = uf.split_into_source_and_target(stacked_image)
 

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -119,9 +119,7 @@ def save_model_weights(model, weights_suffix):
 
 def predict(weight_name="latest.h5"):
     set_configs()
-    batch_size = 1
-    input_shape = (batch_size, opts.SNIPPET_LEN, opts.IM_HEIGHT, opts.IM_WIDTH, 3)
-    model = ModelFactory(input_shape=input_shape).get_model()
+    model = ModelFactory(global_batch=1).get_model()
     model = try_load_weights(model, weight_name)
     model.compile(optimizer="sgd", loss="mean_absolute_error")
 

--- a/model/model_util/augmentation.py
+++ b/model/model_util/augmentation.py
@@ -367,7 +367,7 @@ def test_augmentations():
 
         ori_images = []
         raw_image_u8 = to_uint8_image(features["image"])
-        ori_images.append(raw_image_u8[0, -opts.IM_HEIGHT:])
+        ori_images.append(raw_image_u8[0, -opts.get_shape("H"):])
         source_image, synth_target = synthesize_target(features)
         ori_images.append(synth_target)
         ori_images.append(source_image)

--- a/model/synthesize/flow_warping.py
+++ b/model/synthesize/flow_warping.py
@@ -87,15 +87,14 @@ def test_reshape_source_images():
     print("src_img shape", bat_img.shape)
 
     # take only left image
-    left_img = bat_img[:, :, :opts.IM_WIDTH]
+    left_img = bat_img[:, :, :opts.get_shape("W")]
     print("left_img shape", left_img.shape)
     cv2.imshow("left_img", left_img[0].numpy().astype(np.uint8))
     cv2.waitKey(10)
 
     # reshape image
     batch = 3
-    numsrc = 5
-    height, width = opts.IM_HEIGHT, opts.IM_WIDTH
+    numsrc, height, width = opts.get_shape("SHC")
 
     # EXECUTE
     rsp_img = tf.reshape(left_img, (batch*numsrc, height, width, 3))

--- a/model/synthesize/test_synthesizing.py
+++ b/model/synthesize/test_synthesizing.py
@@ -8,10 +8,11 @@ from config import opts
 from model.synthesize.synthesize_base import SynthesizeSingleScale, SynthesizeMultiScale
 from model.synthesize.bilinear_interp import BilinearInterpolation
 from tfrecords.tfrecord_reader import TfrecordGenerator
+from model.model_util.augmentation import augmentation_factory
 import utils.convert_pose as cp
 import utils.util_funcs as uf
 
-WAIT_KEY = 200
+WAIT_KEY = 0
 
 
 def test_synthesize_batch_multi_scale():
@@ -20,17 +21,21 @@ def test_synthesize_batch_multi_scale():
     실제 target image와 복원된 "multi" scale target image를 눈으로 비교
     """
     print("===== start test_synthesize_batch_multi_scale")
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_generator()
+    dataname, split = "waymo", "train"
+    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, f"{dataname}_{split}")).get_generator()
+    augmenter = augmentation_factory(opts.AUGMENT_PROBS)
 
     for i, features in enumerate(dataset):
         print("----- test_synthesize_batch_multi_scale")
-        stacked_image = features['image']
+        features = augmenter(features)
+        image5d = features['image5d']
         intrinsic = features['intrinsic']
         depth_gt = features['depth_gt']
         pose_gt = features['pose_gt']
-        source_image, target_image = uf.split_into_source_and_target(stacked_image)
+        source_image, target_image = image5d[:, :4], image5d[:, 4]
         depth_gt_ms = uf.multi_scale_depths(depth_gt, [1, 2, 4, 8])
         pred_pose = cp.pose_matr2rvec_batch(pose_gt)
+        cv2.imshow("depth", depth_gt[0].numpy())
 
         # EXECUTE
         synth_target_ms = SynthesizeMultiScale()(source_image, intrinsic, depth_gt_ms, pred_pose)
@@ -38,10 +43,11 @@ def test_synthesize_batch_multi_scale():
         # compare target image and reconstructed images
         # recon_img0[0, 0]: reconstructed from the first image
         target_image = uf.to_uint8_image(target_image).numpy()[0]
-        source_image = uf.to_uint8_image(source_image).numpy()[0, 0:opts.get_shape("H")]
+        source_image = uf.to_uint8_image(source_image).numpy()[0, 0]
         recon_img0 = uf.to_uint8_image(synth_target_ms[0]).numpy()[0, 0]
         recon_img1 = uf.to_uint8_image(synth_target_ms[2]).numpy()[0, 0]
-        recon_img1 = cv2.resize(recon_img1, opts.get_shape("WH"), cv2.INTER_NEAREST)
+        print("recon image size:", recon_img0.shape, recon_img1.shape, opts.get_shape("WH", dataname))
+        recon_img1 = cv2.resize(recon_img1, opts.get_shape("WH", dataname), cv2.INTER_NEAREST)
         view = np.concatenate([source_image, target_image, recon_img0, recon_img1], axis=0)
         print("Check if all the images are the same")
         cv2.imshow("source, target, and reconstructed", view)
@@ -298,13 +304,13 @@ def test_reconstruct_bilinear_interp():
 def test_all():
     np.set_printoptions(precision=4, suppress=True, linewidth=100)
     test_synthesize_batch_multi_scale()
-    test_synthesize_batch_view()
-    test_reshape_source_images()
-    test_scale_intrinsic()
-    test_pixel2cam()
-    test_transform_to_source()
-    test_pixel_weighting()
-    test_reconstruct_bilinear_interp()
+    # test_synthesize_batch_view()
+    # test_reshape_source_images()
+    # test_scale_intrinsic()
+    # test_pixel2cam()
+    # test_transform_to_source()
+    # test_pixel_weighting()
+    # test_reconstruct_bilinear_interp()
 
 
 if __name__ == "__main__":

--- a/model/synthesize/test_synthesizing.py
+++ b/model/synthesize/test_synthesizing.py
@@ -38,10 +38,10 @@ def test_synthesize_batch_multi_scale():
         # compare target image and reconstructed images
         # recon_img0[0, 0]: reconstructed from the first image
         target_image = uf.to_uint8_image(target_image).numpy()[0]
-        source_image = uf.to_uint8_image(source_image).numpy()[0, 0:opts.IM_HEIGHT]
+        source_image = uf.to_uint8_image(source_image).numpy()[0, 0:opts.get_shape("H")]
         recon_img0 = uf.to_uint8_image(synth_target_ms[0]).numpy()[0, 0]
         recon_img1 = uf.to_uint8_image(synth_target_ms[2]).numpy()[0, 0]
-        recon_img1 = cv2.resize(recon_img1, (opts.IM_WIDTH, opts.IM_HEIGHT), cv2.INTER_NEAREST)
+        recon_img1 = cv2.resize(recon_img1, opts.get_shape("WH"), cv2.INTER_NEAREST)
         view = np.concatenate([source_image, target_image, recon_img0, recon_img1], axis=0)
         print("Check if all the images are the same")
         cv2.imshow("source, target, and reconstructed", view)
@@ -126,7 +126,7 @@ def test_reshape_source_images():
     print("reorganized source image shape", reshaped_image.get_shape().as_list())
     reshaped_image = uf.to_uint8_image(reshaped_image).numpy()
     imgidx = 2
-    scsize = (int(opts.IM_HEIGHT/2), int(opts.IM_WIDTH/2))
+    scsize = opts.get_shape("HW", scale_div=2)
     scaled_image = tf.image.resize(source_image, size=(scsize[0]*4, scsize[1]), method="bilinear")
     scaled_image = uf.to_uint8_image(scaled_image).numpy()
     scaled_image = scaled_image[0, scsize[0]*imgidx:scsize[0]*(imgidx+1)]

--- a/prepare_data/data_factories.py
+++ b/prepare_data/data_factories.py
@@ -1,0 +1,53 @@
+from config import opts
+from utils.util_class import WrongInputException
+import prepare_data.readers.kitti_reader as kr
+import prepare_data.readers.city_reader as cr
+import prepare_data.example_maker as em
+import prepare_data.list_drives as ld
+
+"""
+ExampleMaker: generates training example, main function is snippet_generator()
+DataLister: list drives (image sequence folders)
+DatasetReader: reads data from files
+"""
+
+
+def example_maker_factory(raw_data_path, pose_avail, depth_avail, stereo=opts.STEREO, snippet_len=opts.SNIPPET_LEN):
+    if stereo:
+        snippet_maker = em.ExampleMakerStereo(raw_data_path, pose_avail, depth_avail, snippet_len)
+    else:
+        snippet_maker = em.ExampleMaker(raw_data_path, pose_avail, depth_avail, snippet_len)
+    return snippet_maker
+
+
+def drive_lister_factory(dataset, split, raw_data_path, save_path):
+    if dataset == "kitti_raw":
+        drive_lister = ld.KittiRawListDrives(raw_data_path, save_path, split)
+    elif dataset == "kitti_odom":
+        drive_lister = ld.KittiOdomListDrives(raw_data_path, save_path, split)
+    elif dataset == "cityscapes":
+        drive_lister = ld.CityListDrives(raw_data_path, save_path, split)
+    elif dataset == "cityscapes_seq":
+        drive_lister = ld.CityListDrives(raw_data_path, save_path, split, "_sequence")
+    else:
+        raise WrongInputException(f"No dataset and split like: {dataset}, {split}")
+    return drive_lister
+
+
+def dataset_reader_factory(raw_data_path, drive_path, dataset, split, stereo=opts.STEREO):
+    if dataset == "kitti_raw" and split == "train":
+        data_reader = kr.KittiRawTrainReader(raw_data_path, drive_path, stereo)
+    elif dataset == "kitti_raw" and split == "test":
+        data_reader = kr.KittiRawTestReader(raw_data_path, drive_path, stereo)
+    elif dataset == "kitti_odom" and split == "train":
+        data_reader = kr.KittiOdomTrainReader(raw_data_path, drive_path, stereo)
+    elif dataset == "kitti_odom" and split == "test":
+        data_reader = kr.KittiOdomTestReader(raw_data_path, drive_path, stereo)
+    elif dataset == "cityscapes":
+        data_reader = cr.CityScapesReader(raw_data_path, drive_path, stereo, split)
+    elif dataset == "cityscapes_seq":
+        data_reader = cr.CityScapesReader(raw_data_path, drive_path, stereo, split, "_sequence")
+    else:
+        raise WrongInputException(f"Wrong dataset and split: {dataset}, {split}")
+    return data_reader
+

--- a/prepare_data/data_factories.py
+++ b/prepare_data/data_factories.py
@@ -14,9 +14,9 @@ DatasetReader: reads data from files
 
 def example_maker_factory(raw_data_path, pose_avail, depth_avail, stereo=opts.STEREO, snippet_len=opts.SNIPPET_LEN):
     if stereo:
-        snippet_maker = em.ExampleMakerStereo(raw_data_path, pose_avail, depth_avail, snippet_len)
+        snippet_maker = em.ExampleMakerStereo(raw_data_path, snippet_len, pose_avail, depth_avail)
     else:
-        snippet_maker = em.ExampleMaker(raw_data_path, pose_avail, depth_avail, snippet_len)
+        snippet_maker = em.ExampleMaker(raw_data_path, snippet_len, pose_avail, depth_avail)
     return snippet_maker
 
 

--- a/prepare_data/example_maker.py
+++ b/prepare_data/example_maker.py
@@ -26,9 +26,7 @@ class ExampleMaker:
         self.num_frames = len(reader.frame_names)
 
     def get_example(self, example_index):
-        frame_index = self.data_reader.get_frame_index(example_index)
-        snippet_frame_inds = self.make_snippet_indices(frame_index)
-
+        snippet_frame_inds = self.make_snippet_indices(example_index)
         example = dict()
         example["index"] = example_index
         example["image"], raw_img_shape = self.load_snippet_frames(snippet_frame_inds)
@@ -43,7 +41,7 @@ class ExampleMaker:
 
     def make_snippet_indices(self, frame_idx):
         halflen = self.snippet_len // 2
-        max_frame_index = self.data_reader.total_num_frames - 1
+        max_frame_index = self.data_reader.num_frames() - 1
         indices = np.arange(frame_idx-halflen, frame_idx+halflen+1)
         indices = np.clip(indices, 0, max_frame_index).tolist()
         return indices

--- a/prepare_data/example_maker.py
+++ b/prepare_data/example_maker.py
@@ -2,7 +2,7 @@ import cv2
 import numpy as np
 
 import settings
-from config import opts, get_raw_data_path
+from config import opts
 import prepare_data.readers.kitti_reader as kr
 import prepare_data.readers.city_reader as cr
 import utils.convert_pose as cp
@@ -52,7 +52,7 @@ class ExampleMaker:
         for idnum in snippet_ids:
             frame = self.data_reader.get_image(idnum)
             raw_img_shape = frame.shape[:2]
-            frame = cv2.resize(frame, dsize=(opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_LINEAR)
+            frame = cv2.resize(frame, dsize=opts.get_shape("WH"), interpolation=cv2.INTER_LINEAR)
             frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
             frames.append(frame)
 
@@ -82,14 +82,14 @@ class ExampleMaker:
         return tgt_to_src_poses
 
     def load_frame_depth(self, frame_idx, raw_img_shape):
-        dst_shape = (opts.IM_HEIGHT, opts.IM_WIDTH)
+        dst_shape = opts.get_shape("HW")
         depth_map = self.data_reader.get_depth_map(frame_idx, raw_img_shape, dst_shape)
         return depth_map
 
     def load_intrinsic(self, raw_img_shape):
         intrinsic = self.data_reader.get_intrinsic()
-        sx = opts.IM_WIDTH / raw_img_shape[1]
-        sy = opts.IM_HEIGHT / raw_img_shape[0]
+        sx = opts.get_shape("W") / raw_img_shape[1]
+        sy = opts.get_shape("H") / raw_img_shape[0]
         out = intrinsic.copy()
         out[0, 0] *= sx
         out[0, 2] *= sx
@@ -113,9 +113,9 @@ class ExampleMakerStereo(ExampleMaker):
         for idnum in snippet_ids:
             img_lef, img_rig = self.data_reader.get_image(idnum)
             raw_img_shape = img_lef.shape[:2]
-            img_lef = cv2.resize(img_lef, (opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_LINEAR)
+            img_lef = cv2.resize(img_lef, opts.get_shape("WH"), interpolation=cv2.INTER_LINEAR)
             img_lef = cv2.cvtColor(img_lef, cv2.COLOR_RGB2BGR)
-            img_rig = cv2.resize(img_rig, (opts.IM_WIDTH, opts.IM_HEIGHT), interpolation=cv2.INTER_LINEAR)
+            img_rig = cv2.resize(img_rig, opts.get_shape("WH"), interpolation=cv2.INTER_LINEAR)
             img_rig = cv2.cvtColor(img_rig, cv2.COLOR_RGB2BGR)
             frame = np.concatenate([img_lef, img_rig], axis=1)
             frames.append(frame)
@@ -126,8 +126,8 @@ class ExampleMakerStereo(ExampleMaker):
     def load_intrinsic(self, raw_img_shape):
         intrin_lef, intrin_rig = self.data_reader.get_intrinsic()
         intrinsic = np.concatenate([intrin_lef, intrin_rig], axis=1)
-        sx = opts.IM_WIDTH / raw_img_shape[1]
-        sy = opts.IM_HEIGHT / raw_img_shape[0]
+        sx = opts.get_shape("W") / raw_img_shape[1]
+        sy = opts.get_shape("H") / raw_img_shape[0]
         intrinsic[0, :] = intrinsic[0, :] * sx
         intrinsic[1, :] = intrinsic[1, :] * sy
         return intrinsic
@@ -148,7 +148,7 @@ class ExampleMakerStereo(ExampleMaker):
         return poses
 
     def load_frame_depth(self, frame_idx, raw_img_shape):
-        dst_shape = (opts.IM_HEIGHT, opts.IM_WIDTH)
+        dst_shape = opts.get_shape("HW")
         depth_lef, depth_rig = self.data_reader.get_depth_map(frame_idx, raw_img_shape, dst_shape)
         depth = np.concatenate([depth_lef, depth_rig], axis=1)
         return depth
@@ -159,7 +159,7 @@ def test_kitti_loader():
     dataset = "kitti_raw"
     maker, reader = dataset_loader_factory(get_raw_data_path(dataset), dataset, "train")
     delay = 0
-    height, width = opts.IM_HEIGHT, opts.IM_WIDTH
+    height, width = opts.get_shape("HW")
     drive_paths = reader.list_drive_paths()
 
     for drive_path in drive_paths:

--- a/prepare_data/list_drives.py
+++ b/prepare_data/list_drives.py
@@ -1,0 +1,137 @@
+import os
+import os.path as op
+from glob import glob
+from utils.util_class import WrongInputException
+
+
+class ListDrivesBase:
+    def __init__(self, srcpath, dstpath, split):
+        self.srcpath = srcpath
+        self.dstpath = dstpath
+        self.split = split
+        self.pose_avail = False
+        self.depth_avail = False
+
+    def list_drive_paths(self):
+        """
+        :return: directory paths to sequences of images
+        """
+        raise NotImplementedError()
+
+    def make_saving_paths(self, drive_path):
+        """
+        :param drive_path: path to source sequence data
+        :return: [image_path, pose_path, depth_path]
+                 specific paths under "dstpath" to save image, pose, and depth
+        """
+        raise NotImplementedError()
+
+
+class KittiRawListDrives(ListDrivesBase):
+    def __init__(self, srcpath, dstpath, split):
+        super().__init__(srcpath, dstpath, split)
+        self.pose_avail = True
+        self.depth_avail = True
+
+    def list_drive_paths(self):
+        prepare_data_path = op.dirname(op.abspath(__file__))
+        filename = op.join(prepare_data_path, "resources", f"kitti_raw_{self.split}_scenes.txt")
+        with open(filename, "r") as f:
+            drives = f.readlines()
+            drives.sort()
+            drives = [tuple(drive.strip("\n").split()) for drive in drives]
+            drives = [self._make_raw_data_path(drive) for drive in drives]
+            print("[list_drive_paths] drive list:", [op.basename(drive) for drive in drives])
+
+        return drives
+
+    def _make_raw_data_path(self, drive):
+        drive_path = op.join(self.srcpath, drive[0], f"{drive[0]}_drive_{drive[1]}_sync")
+        return drive_path
+
+    def make_saving_paths(self, drive_path):
+        date, drive_id = self._parse_drive_path(drive_path)
+        image_path = op.join(self.dstpath, f"{date}_{drive_id}")
+        pose_path = op.join(image_path, "pose") if self.pose_avail else None
+        depth_path = op.join(image_path, "depth") if self.depth_avail else None
+        return image_path, pose_path, depth_path
+
+    def _parse_drive_path(self, drive_path):
+        dirsplits = op.basename(drive_path).split("_")
+        date = f"{dirsplits[0]}_{dirsplits[1]}_{dirsplits[2]}"
+        drive_id = dirsplits[4]
+        return date, drive_id
+
+
+class KittiOdomListDrives(ListDrivesBase):
+    def __init__(self, srcpath, dstpath, split):
+        super().__init__(srcpath, dstpath, split)
+        self.pose_avail = True if split is "test" else False
+
+    def list_drive_paths(self):
+        if self.split is "train":
+            drives = [f"{i:02d}" for i in range(11, 22)]
+        else:
+            drives = [f"{i:02d}" for i in range(0, 11)]
+        drives = [self._make_raw_data_path(drive) for drive in drives]
+        print("[list_drive_paths] drive list:", [op.basename(drive) for drive in drives])
+        return drives
+
+    def _make_raw_data_path(self, drive):
+        drive_path = op.join(self.srcpath, "sequences", drive)
+        return drive_path
+
+    def make_saving_paths(self, drive_path):
+        drive = op.basename(drive_path)
+        image_path = op.join(self.dstpath, drive)
+        pose_path = op.join(image_path, "pose") if self.pose_avail else None
+        depth_path = op.join(image_path, "depth") if self.depth_avail else None
+        return image_path, pose_path, depth_path
+
+
+class CityListDrives(ListDrivesBase):
+    def __init__(self, srcpath, dstpath, split, dir_suffix=""):
+        super().__init__(srcpath, dstpath, split)
+        self.depth_avail = True
+        self.left_img_dir = "leftImg8bit"
+        self.dir_suffix = dir_suffix
+
+    """
+    Public methods used outside this class
+    """
+
+    def list_drive_paths(self):
+        split_path = op.join(self.srcpath, self.left_img_dir + self.dir_suffix, self.split)
+        if not op.isdir(split_path):
+            raise WrongInputException("[list_sequence_paths] path does NOT exist:" + split_path)
+
+        city_names = os.listdir(split_path)
+        city_names = [city for city in city_names if op.isdir(op.join(split_path, city))]
+        total_sequences = []
+        for city in city_names:
+            pattern = op.join(split_path, city, "*.png")
+            files = glob(pattern)
+            seq_numbers = [file.split("_")[-3] for file in files]
+            seq_numbers = list(set(seq_numbers))
+            seq_numbers.sort()
+            seq_paths = [op.join(self.split, city, f"{city}_{seq}") for seq in seq_numbers]
+            total_sequences.extend(seq_paths)
+
+        # total_sequences: list of ["city/city_seqind"]
+        print("[list_drive_paths]", total_sequences)
+        return total_sequences
+
+    def make_saving_paths(self, drive_path):
+        """
+        :param drive_path: sequence path like "train/bochum/bochum_000000"
+        :return: [image_path, pose_path, depth_path]
+                 specific paths under "dstpath" to save image, pose, and depth
+        """
+        # e.g. image_path = "opts.DATAPATH/srcdata/cityscapes_train/bochum/bochum_000000"
+        image_path = op.join(self.dstpath, op.basename(drive_path))
+        pose_path = op.join(image_path, "pose") if self.pose_avail else None
+        depth_path = op.join(image_path, "depth") if self.depth_avail else None
+        return image_path, pose_path, depth_path
+
+
+

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -37,6 +37,7 @@ def prepare_and_save_snippets(snippet_maker, drive_lister, dataset, split):
     num_drives = len(drive_paths)
     for i, drive_path in enumerate(drive_paths):
         data_reader = df.dataset_reader_factory(get_raw_data_path(dataset), drive_path, dataset, split)
+        data_reader.init_drive()
         num_frames = data_reader.num_frames()
         if num_frames == 0:
             print("this drive is EMPTY:", drive_path)

--- a/prepare_data/prepare_data_main.py
+++ b/prepare_data/prepare_data_main.py
@@ -6,7 +6,7 @@ import shutil
 import glob
 
 import settings
-from config import opts, get_raw_data_path
+from config import opts
 from utils.util_funcs import print_progress_status
 from utils.util_class import PathManager
 import prepare_data.data_factories as df
@@ -20,8 +20,8 @@ def prepare_datasets():
                 create_validation_set(dataset, "test")
             else:
                 dstpath = op.join(opts.DATAPATH_SRC, f"{dataset}_{split}")
-                drive_lister = df.drive_lister_factory(dataset, split, get_raw_data_path(dataset), dstpath)
-                snippet_maker = df.example_maker_factory(get_raw_data_path(dataset),
+                drive_lister = df.drive_lister_factory(dataset, split, opts.get_raw_data_path(dataset), dstpath)
+                snippet_maker = df.example_maker_factory(opts.get_raw_data_path(dataset),
                                                          drive_lister.pose_avail, drive_lister.depth_avail)
                 prepare_and_save_snippets(snippet_maker, drive_lister, dataset, split)
 
@@ -36,7 +36,7 @@ def prepare_and_save_snippets(snippet_maker, drive_lister, dataset, split):
 
     num_drives = len(drive_paths)
     for i, drive_path in enumerate(drive_paths):
-        data_reader = df.dataset_reader_factory(get_raw_data_path(dataset), drive_path, dataset, split)
+        data_reader = df.dataset_reader_factory(opts.get_raw_data_path(dataset), drive_path, dataset, split)
         data_reader.init_drive()
         num_frames = data_reader.num_frames()
         if num_frames == 0:
@@ -70,7 +70,7 @@ def save_example(example, filename, data_paths):
     frames = example["image"]
     filepath = op.join(image_path, f"{filename}.png")
     cv2.imwrite(filepath, frames)
-    center_y, center_x = (opts.IM_HEIGHT // 2, opts.IM_WIDTH // 2)
+    center_y, center_x = opts.get_shape("HW", 2)
 
     filepath = op.join(image_path, "intrinsic.txt")
     if not op.isfile(filepath):

--- a/prepare_data/readers/city_reader.py
+++ b/prepare_data/readers/city_reader.py
@@ -12,9 +12,6 @@ from prepare_data.readers.reader_base import DataReaderBase
 class CityScapesReader(DataReaderBase):
     def __init__(self, base_path, drive_path, stereo=False, split="", dir_suffix=""):
         super().__init__(base_path, drive_path, stereo)
-        self.base_path = base_path
-        self.pose_avail = False
-        self.depth_avail = True
         self.left_img_dir = "leftImg8bit"
         self.split = split
         self.dir_suffix = dir_suffix
@@ -25,15 +22,12 @@ class CityScapesReader(DataReaderBase):
     """
     Public methods used outside this class
     """
-    def init_drive(self, base_path, drive_path):
+    def init_drive(self):
         """
         reset variables for a new sequence like intrinsic, extrinsic, and last index
-        :param drive_path: sequence path like "train/bochum/bochum_000000"
-        :return: number of frames
-
         self.frame_names: full path of frame files without extension
         """
-        self.frame_names, self.frame_indices = self._list_frames(drive_path)
+        self.frame_names, self.frame_indices = self.list_frames(self.drive_path)
         self.intrinsic = self._find_camera_matrix()
 
     def num_frames(self):
@@ -72,7 +66,7 @@ class CityScapesReader(DataReaderBase):
     """
     Private methods used inside this class
     """
-    def _list_frames(self, drive_path):
+    def list_frames(self, drive_path):
         """
         :param drive_path: sequence path like "train/bochum/bochum_000000"
         :return frame_files: list of frame paths like ["train/bochum/bochum_000000_000001"]

--- a/prepare_data/readers/city_reader.py
+++ b/prepare_data/readers/city_reader.py
@@ -27,7 +27,7 @@ class CityScapesReader(DataReaderBase):
         reset variables for a new sequence like intrinsic, extrinsic, and last index
         self.frame_names: full path of frame files without extension
         """
-        self.frame_names, self.frame_indices = self.list_frames(self.drive_path)
+        self.frame_names = self.list_frames(self.drive_path)
         self.intrinsic = self._find_camera_matrix()
 
     def num_frames(self):
@@ -60,12 +60,6 @@ class CityScapesReader(DataReaderBase):
         filename = op.basename(self.frame_names[example_index])
         return filename.split("_")[-1]
 
-    def get_frame_index(self, example_index):
-        return self.frame_indices[example_index]
-
-    """
-    Private methods used inside this class
-    """
     def list_frames(self, drive_path):
         """
         :param drive_path: sequence path like "train/bochum/bochum_000000"
@@ -80,8 +74,11 @@ class CityScapesReader(DataReaderBase):
         frame_files = [op.join(split_city, file) for file in frame_files]
         frame_files.sort()
         frame_indices = [int(file.split("_")[-1]) for file in frame_files]
-        return frame_files, frame_indices
+        return frame_files
 
+    """
+    Private methods used inside this class
+    """
     def _find_camera_matrix(self):
         drive_path = "_".join(self.frame_names[0].split("_")[:-1])
         # e.g. file_pattern = /path/to/cityscapes/camera/train/bochum/bochum_000000_*_camera.png
@@ -100,8 +97,7 @@ class CityScapesReader(DataReaderBase):
 
     def _read_depth_map(self, filename, target_shape):
         image = cv2.imread(filename, cv2.IMREAD_ANYDEPTH)
-        assert image is not None, f"[_read_depth_map] There is no disparity image " \
-                                  + op.basename(filename) + " in split " + self.split
+        assert image is not None, f"[_read_depth_map] There is no disparity image " + op.basename(filename)
         disparity = (image.astype(np.float32) - 1.) / 256.
         depth = np.where(image > 0., disparity, 0)
         depth = cv2.resize(depth, (target_shape[1], target_shape[0]), cv2.INTER_NEAREST)

--- a/prepare_data/readers/kitti_reader.py
+++ b/prepare_data/readers/kitti_reader.py
@@ -9,32 +9,30 @@ import utils.convert_pose as cp
 
 
 class KittiReader(DataReaderBase):
-    def __init__(self, base_path, stereo=False):
+    def __init__(self, base_path, drive_path, stereo=False):
         """
         when 'stereo' is True, 'get_xxx' function returns two data in tuple
         """
-        super().__init__(base_path, stereo)
         self.drive_loader = None
-        self.static_frames = self._read_static_frames()
+        super().__init__(base_path, drive_path, stereo)
 
     """
     Public methods used outside this class
     """
-    def list_drive_paths(self):
-        raise NotImplementedError()
-
-    def init_drive(self, drive_path):
+    def init_drive(self, base_path, drive_path):
         """
         self.frame_names: frame file names without extension
         """
-        self.drive_loader = self._create_drive_loader(drive_path)
-        self.frame_names, self.frame_indices, self.total_num_frames = self._list_frames(drive_path)
+        if (not base_path) or (not drive_path):
+            return
+        self.drive_loader = self._create_drive_loader(base_path, drive_path)
+        self.static_frames = self._read_static_frames()
+        self.frame_names, self.frame_indices = self._list_frames(drive_path)
         self.intrinsic = self._find_camera_matrix()
         self.T_left_right = self._find_stereo_extrinsic()
-        return len(self.frame_names)
 
-    def make_saving_paths(self, dstpath, drive_path):
-        raise NotImplementedError()
+    def num_frames(self):
+        return len(self.frame_names)
 
     def get_image(self, index):
         images = self.drive_loader.get_rgb(index)
@@ -64,20 +62,6 @@ class KittiReader(DataReaderBase):
     """
     Private methods used inside this class
     """
-    def _verify_drives(self, drives):
-        self.frame_count = [0, 0]
-        verified_drives = []
-        for drive_path in drives:
-            if not op.isdir(drive_path):
-                continue
-            frame_names, frame_inds, total_frames = self._list_frames(drive_path)
-            if len(frame_inds) == 0:
-                continue
-            verified_drives.append(drive_path)
-
-        print("[_verify_drives] frame counts:", dict(zip(["total", "non-static"], self.frame_count)))
-        return verified_drives
-
     def _read_static_frames(self):
         filename = self._static_frame_filename()
         with open(filename, "r") as fr:
@@ -100,10 +84,7 @@ class KittiReader(DataReaderBase):
         else:
             return intrinsic
 
-    def _make_raw_data_path(self, drive):
-        raise NotImplementedError()
-
-    def _create_drive_loader(self, drive_path):
+    def _create_drive_loader(self, base_path, drive_path):
         raise NotImplementedError()
 
     def _list_frames(self, drive_path):
@@ -123,22 +104,8 @@ class KittiReader(DataReaderBase):
 
 
 class KittiRawReader(KittiReader):
-    def __init__(self, base_path, stereo=False):
-        super().__init__(base_path, stereo)
-        self.pose_avail = True
-        self.depth_avail = True
-
-    def list_drive_paths(self):
-        prepare_data_path = op.dirname(op.dirname(op.abspath(__file__)))
-        filename = op.join(prepare_data_path, "resources", f"kitti_raw_{self.split}_scenes.txt")
-        with open(filename, "r") as f:
-            drives = f.readlines()
-            drives.sort()
-            drives = [tuple(drive.strip("\n").split()) for drive in drives]
-            drives = [self._make_raw_data_path(drive) for drive in drives]
-            drives = self._verify_drives(drives)
-            print("[list_drive_paths] drive list:", [op.basename(drive) for drive in drives])
-            return drives
+    def __init__(self, base_path, drive_path, stereo=False):
+        super().__init__(base_path, drive_path, stereo)
 
     def parse_drive_path(self, drive_path):
         dirsplits = op.basename(drive_path).split("_")
@@ -154,13 +121,6 @@ class KittiRawReader(KittiReader):
         frame_files = glob(frame_pattern)
         frame_files.sort()
         return frame_files
-
-    def make_saving_paths(self, dstpath, drive_path):
-        date, drive_id = self.parse_drive_path(drive_path)
-        image_path = op.join(dstpath, f"{date}_{drive_id}")
-        pose_path = op.join(image_path, "pose") if self.pose_avail else None
-        depth_path = op.join(image_path, "depth") if self.depth_avail else None
-        return image_path, pose_path, depth_path
 
     def get_quat_pose(self, index):
         T_w_imu = self.drive_loader.oxts[index].T_w_imu
@@ -186,29 +146,24 @@ class KittiRawReader(KittiReader):
         else:
             return depth
 
-    def _make_raw_data_path(self, drive):
-        drive_path = op.join(self.base_path, drive[0], f"{drive[0]}_drive_{drive[1]}_sync")
-        return drive_path
-
     def _static_frame_filename(self):
         prepare_data_path = op.dirname(op.dirname(op.abspath(__file__)))
         return op.join(prepare_data_path, "resources", "kitti_raw_static_frames.txt")
 
-    def _create_drive_loader(self, drive_path):
-        print(f"[_create_drive_loader] drive: {op.basename(drive_path)}, pose avail: {self.pose_avail}, depth avail: {self.depth_avail}")
+    def _create_drive_loader(self, base_path, drive_path):
+        print(f"[_create_drive_loader] drive: {op.basename(drive_path)}")
         date, drive_id = self.parse_drive_path(drive_path)
-        return pykitti.raw(self.base_path, date, drive_id)
+        return pykitti.raw(base_path, date, drive_id)
 
 
 class KittiRawTrainReader(KittiRawReader):
-    def __init__(self, base_path, stereo=False):
-        super().__init__(base_path, stereo)
+    def __init__(self, base_path, drive_path, stereo=False):
+        super().__init__(base_path, drive_path, stereo)
         self.split = "train"
 
     def _list_frames(self, drive_path):
         # list frame files in drive_path
         frame_paths = self._list_frame_files(drive_path)
-        total_num_frames = len(frame_paths)
         frame_files_all = []
         # reformat to 'date drive_id frame_id' format like '2011_09_26 0001 0000000000'
         for frame in frame_paths:
@@ -219,7 +174,7 @@ class KittiRawTrainReader(KittiRawReader):
         frame_files = self._remove_static_frames(frame_files_all)
         if len(frame_files) < 2:
             # print(f"[find_frame_names] {op.basename(drive_path)}: {len(frame_files_all)} -> 0")
-            return [], [], 0
+            return [], []
 
         self.frame_count[1] += len(frame_files)
         frame_names = [frame.split()[-1] for frame in frame_files]
@@ -228,17 +183,16 @@ class KittiRawTrainReader(KittiRawReader):
         # remove first and last two frames in training drive data
         frame_names = frame_names[2:-2]
         frame_ids = [int(name) for name in frame_names]
-        return frame_names, frame_ids, total_num_frames
+        return frame_names, frame_ids
 
 
 class KittiRawTestReader(KittiRawReader):
-    def __init__(self, base_path, stereo=False):
-        super().__init__(base_path, stereo)
+    def __init__(self, base_path, drive_path, stereo=False):
+        super().__init__(base_path, drive_path, stereo)
         self.split = "test"
 
     def _list_frames(self, drive_path):
         frame_paths = self._list_frame_files(drive_path)
-        total_num_frames = len(frame_paths)
         drive_splits = drive_path.split("/")
         # format drive_path like 'date drive'
         drive_id = f"{drive_splits[-2]} {drive_splits[-1][-9:-5]}"
@@ -254,20 +208,13 @@ class KittiRawTestReader(KittiRawReader):
             frame_names.sort()
             # print(f"[find_frame_names] {op.basename(drive_path)}: {len(frame_files_all)} -> {len(frame_names)}")
             frame_ids = [int(name) for name in frame_names]
-        return frame_names, frame_ids, total_num_frames
+        return frame_names, frame_ids
 
 
 class KittiOdomReader(KittiReader):
-    def __init__(self, base_path, stereo=False):
-        super().__init__(base_path, stereo)
+    def __init__(self, base_path, drive_path, stereo=False):
+        super().__init__(base_path, drive_path, stereo)
         self.poses = []
-
-    def make_saving_paths(self, dstpath, drive_path):
-        drive = op.basename(drive_path)
-        image_path = op.join(dstpath, drive)
-        pose_path = op.join(image_path, "pose") if self.pose_avail else None
-        depth_path = op.join(image_path, "depth") if self.depth_avail else None
-        return image_path, pose_path, depth_path
 
     def get_quat_pose(self, index):
         raise NotImplementedError()
@@ -280,15 +227,8 @@ class KittiOdomReader(KittiReader):
         prepare_data_path = op.dirname(op.dirname(op.abspath(__file__)))
         return op.join(prepare_data_path, "resources", "kitti_odom_static_frames.txt")
 
-    def list_drive_paths(self):
+    def _create_drive_loader(self, base_path, drive_path):
         raise NotImplementedError()
-
-    def _create_drive_loader(self, drive_path):
-        raise NotImplementedError()
-
-    def _make_raw_data_path(self, drive):
-        drive_path = op.join(self.base_path, "sequences", drive)
-        return drive_path
 
     def _list_frames(self, drive_path):
         raise NotImplementedError()
@@ -301,31 +241,21 @@ class KittiOdomReader(KittiReader):
 
 
 class KittiOdomTrainReader(KittiOdomReader):
-    def __init__(self, base_path, stereo=False):
-        super().__init__(base_path, stereo)
-        self.pose_avail = False
-        self.depth_avail = False
-
-    def list_drive_paths(self):
-        drives = [f"{i:02d}" for i in range(11, 22)]
-        drives = [self._make_raw_data_path(drive) for drive in drives]
-        drives = self._verify_drives(drives)
-        print("[list_drive_paths] drive list:", [op.basename(drive) for drive in drives])
-        return drives
+    def __init__(self, base_path, drive_path, stereo=False):
+        super().__init__(base_path, drive_path, stereo)
 
     def get_quat_pose(self, index):
         # no depth available for kitti_odom_train dataset
         return None
 
-    def _create_drive_loader(self, drive_path):
+    def _create_drive_loader(self, base_path, drive_path):
         drive = op.basename(drive_path)
-        print(f"[_create_drive_loader] drive: {drive}, pose avail: {self.pose_avail}, depth avail: {self.depth_avail}")
-        return pykitti.odometry(self.base_path, drive)
+        print(f"[_create_drive_loader] drive: {drive}")
+        return pykitti.odometry(base_path, drive)
 
     def _list_frames(self, drive_path):
         # list frame files in drive_path
         frame_paths = self._list_frame_files(drive_path)
-        total_num_frames = len(frame_paths)
         frame_files_all = []
         # reformat file paths into 'drive_id frame_id' format like '01 0000000000'
         for frame in frame_paths:
@@ -336,7 +266,7 @@ class KittiOdomTrainReader(KittiOdomReader):
         frame_files = self._remove_static_frames(frame_files_all)
         if len(frame_files) < 2:
             print(f"[find_frame_names] {op.basename(drive_path)}: {len(frame_files_all)} -> 0")
-            return []
+            return [], []
 
         self.frame_count[1] += len(frame_files)
         frame_names = [frame.split()[-1] for frame in frame_files]
@@ -345,22 +275,13 @@ class KittiOdomTrainReader(KittiOdomReader):
         # remove first and last two frames in training drive data
         frame_names = frame_names[2:-2]
         frame_ids = [int(name) for name in frame_names]
-        return frame_names, frame_ids, total_num_frames
+        return frame_names, frame_ids
 
 
 class KittiOdomTestReader(KittiOdomReader):
-    def __init__(self, base_path, stereo=False):
-        super().__init__(base_path, stereo)
-        self.pose_avail = True
-        self.depth_avail = False
+    def __init__(self, base_path, drive_path, stereo=False):
+        super().__init__(base_path, drive_path, stereo)
         self.remove_static = False
-
-    def list_drive_paths(self):
-        drives = [f"{i:02d}" for i in range(0, 11)]
-        drives = [self._make_raw_data_path(drive) for drive in drives]
-        drives = self._verify_drives(drives)
-        print("[list_drive_paths] drive list:", [op.basename(drive) for drive in drives])
-        return drives
 
     def get_quat_pose(self, index):
         T_w_cam2 = self.poses[index].reshape((3, 4))
@@ -374,17 +295,16 @@ class KittiOdomTestReader(KittiOdomReader):
         else:
             return pose
 
-    def _create_drive_loader(self, drive_path):
+    def _create_drive_loader(self, base_path, drive_path):
         drive = op.basename(drive_path)
-        pose_file = op.join(self.base_path, "poses", drive+".txt")
+        pose_file = op.join(base_path, "poses", drive+".txt")
         self.poses = np.loadtxt(pose_file)
-        print(f"[_create_drive_loader] drive: {drive}, pose avail: {self.pose_avail}, depth avail: {self.depth_avail}")
-        return pykitti.odometry(self.base_path, drive)
+        print(f"[_create_drive_loader] drive: {drive}")
+        return pykitti.odometry(base_path, drive)
 
     def _list_frames(self, drive_path):
         # list frame files in drive_path
         frame_paths = self._list_frame_files(drive_path)
-        total_num_frames = len(frame_paths)
         frame_files = []
         # reformat file paths into 'drive_id frame_id' format like '01 0000000000'
         for frame in frame_paths:
@@ -398,4 +318,4 @@ class KittiOdomTestReader(KittiOdomReader):
         frame_names.sort()
         # print(f"[find_frame_names] {op.basename(drive_path)}: {len(frame_files)} -> {len(frame_inds)}")
         frame_ids = [int(name) for name in frame_names]
-        return frame_names, frame_ids, total_num_frames
+        return frame_names, frame_ids

--- a/prepare_data/readers/kitti_reader.py
+++ b/prepare_data/readers/kitti_reader.py
@@ -27,7 +27,7 @@ class KittiReader(DataReaderBase):
             return
         self.drive_loader = self._create_drive_loader()
         self.static_frames = self._read_static_frames()
-        self.frame_names, self.frame_indices = self.list_frames(self.drive_path)
+        self.frame_names = self.list_frames(self.drive_path)
         self.intrinsic = self._find_camera_matrix()
         self.T_left_right = self._find_stereo_extrinsic()
 
@@ -55,9 +55,6 @@ class KittiReader(DataReaderBase):
 
     def get_filename(self, example_index):
         return self.frame_names[example_index]
-
-    def get_frame_index(self, example_index):
-        return self.frame_indices[example_index]
 
     """
     Private methods used inside this class

--- a/prepare_data/readers/reader_base.py
+++ b/prepare_data/readers/reader_base.py
@@ -2,32 +2,41 @@
 class DataReaderBase:
     def __init__(self, base_path, drive_path, stereo=False):
         """
+        :param base_path: root path of dataset
+        :param drive_path: sequence drectory path
         when 'stereo' is True, 'get_xxx' function returns two data in tuple
         """
+        self.base_path = base_path
+        self.drive_path = drive_path
         self.stereo = stereo
         self.split = ""
         self.frame_count = [0, 0]
         self.frame_names = []
         self.frame_indices = []
-        self.total_num_frames = 0
         self.intrinsic = None
         self.T_left_right = None
         self.static_frames = []
-        self.init_drive(base_path, drive_path)
 
     """
     Public methods used outside this class
     """
-    def init_drive(self, base_path, drive_path):
+    def init_drive(self):
         """
         reset variables for a new sequence like intrinsic, extrinsic, and last index
-        :param base_path: root path of dataset
-        :param drive_path: sequence drectory path
-        :return: number of frames
+        """
+        raise NotImplementedError()
+
+    def list_frames(self, drive_path):
+        """
+        :param drive_path: path to data of a drive
+        :return: list of frame names and indices
         """
         raise NotImplementedError()
 
     def num_frames(self):
+        """
+        :return: number of frames of the drive
+        """
         raise NotImplementedError()
 
     def get_image(self, index):

--- a/prepare_data/readers/reader_base.py
+++ b/prepare_data/readers/reader_base.py
@@ -1,45 +1,33 @@
 
 class DataReaderBase:
-    def __init__(self, base_path, stereo=False):
+    def __init__(self, base_path, drive_path, stereo=False):
         """
         when 'stereo' is True, 'get_xxx' function returns two data in tuple
         """
-        self.base_path = base_path
         self.stereo = stereo
         self.split = ""
-        self.pose_avail = True
-        self.depth_avail = True
         self.frame_count = [0, 0]
         self.frame_names = []
         self.frame_indices = []
         self.total_num_frames = 0
         self.intrinsic = None
         self.T_left_right = None
+        self.static_frames = []
+        self.init_drive(base_path, drive_path)
 
     """
     Public methods used outside this class
     """
-    def list_drive_paths(self):
-        """
-        :return: directory paths to sequences of images
-        """
-        raise NotImplementedError()
-
-    def init_drive(self, drive_path):
+    def init_drive(self, base_path, drive_path):
         """
         reset variables for a new sequence like intrinsic, extrinsic, and last index
+        :param base_path: root path of dataset
         :param drive_path: sequence drectory path
         :return: number of frames
         """
         raise NotImplementedError()
 
-    def make_saving_paths(self, dstpath, drive_path):
-        """
-        :param dstpath: path to save reorganized files
-        :param drive_path: path to source sequence data
-        :return: [image_path, pose_path, depth_path]
-                 specific paths under "dstpath" to save image, pose, and depth
-        """
+    def num_frames(self):
         raise NotImplementedError()
 
     def get_image(self, index):

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -37,17 +37,15 @@ def convert_to_tfrecords_directly():
                 print("[convert_to_tfrecords] tfrecord already created in", tfrpath)
                 continue
 
-            with PathManager([tfrpath]) as pm:
-                srcpath = opts.get_raw_data_path(dataset)
-                tfrmaker = tfrecord_maker_factory(dataset, split, srcpath, tfrpath)
-                tfrmaker.make(opts.LIMIT_FRAMES)
-                # if set_ok() was NOT excuted, the generated path is removed
-                pm.set_ok()
+            srcpath = opts.get_raw_data_path(dataset)
+            tfrmaker = tfrecord_maker_factory(dataset, split, srcpath, tfrpath)
+            tfrmaker.make(opts.LIMIT_FRAMES)
 
 
 def tfrecord_maker_factory(dataset, split, srcpath, tfrpath):
     if dataset is "waymo":
-        return tm.WaymoTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, opts.get_shape("SHWC"))
+        return tm.WaymoTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO,
+                                     opts.get_shape("SHWC", dataset))
     else:
         WrongInputException(f"Invalid dataset: {dataset}")
 

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -4,7 +4,7 @@ from glob import glob
 import numpy as np
 
 import settings
-from config import opts
+from config import opts, get_raw_data_path
 from utils.util_class import PathManager
 from tfrecords.tfrecord_writer import TfrecordMaker
 
@@ -13,7 +13,6 @@ def convert_to_tfrecords():
     src_paths = glob(op.join(opts.DATAPATH_SRC, "*"))
     src_paths = [path for path in src_paths if op.isdir(path)]
     print("[convert_to_tfrecords] top paths:", src_paths)
-
     for srcpath in src_paths:
         tfrpath = op.join(opts.DATAPATH_TFR, op.basename(srcpath))
         if op.isdir(tfrpath):

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -4,7 +4,7 @@ from glob import glob
 import numpy as np
 
 import settings
-from config import opts, get_raw_data_path
+from config import opts
 from utils.util_class import PathManager
 from tfrecords.tfrecord_writer import TfrecordMaker
 
@@ -20,12 +20,18 @@ def convert_to_tfrecords():
         else:
             with PathManager([tfrpath]) as pm:
                 os.makedirs(tfrpath, exist_ok=True)
-                tfrmaker = TfrecordMaker(srcpath, tfrpath, opts.STEREO,
-                                         (opts.SNIPPET_LEN, opts.IM_HEIGHT, opts.IM_WIDTH, 3),
+                tfrmaker = TfrecordMaker(srcpath, tfrpath, opts.STEREO, opts.get_shape("SHWC"),
                                          opts.LIMIT_FRAMES, opts.SHUFFLE_TFRECORD_INPUT)
                 tfrmaker.make()
                 # if set_ok() was NOT excuted, the generated path is removed
                 pm.set_ok()
+
+
+def convert_to_tfrecords_directly():
+    datasets = opts.DATASETS_TO_PREPARE
+    for dataset, splits in datasets.items():
+        for split in splits:
+            dstpath = op.join(opts.DATAPATH_SRC, f"{dataset}_{split}")
 
 
 if __name__ == "__main__":

--- a/tfrecords/data_feeders.py
+++ b/tfrecords/data_feeders.py
@@ -184,7 +184,7 @@ class ImageReader(FileReader):
         return image
 
     def preprocess(self, image):
-        height, width = opts.IM_HEIGHT, opts.IM_WIDTH
+        height, width = opts.get_shape("HW")
         half_len = int(opts.SNIPPET_LEN // 2)
         # TODO IMPORTANT!
         #   image in 'srcdata': [src--, src-, target, src+, src++]
@@ -198,7 +198,7 @@ class ImageReader(FileReader):
 
 class ImageReaderStereo(ImageReader):
     def split_data(self, image):
-        width = opts.IM_WIDTH
+        width = opts.get_shape("W")
         left, right = image[:, :width], image[:, width:]
         return [left, right]
 
@@ -250,7 +250,7 @@ class DepthReader(FileReader):
 
 class DepthReaderStereo(DepthReader):
     def split_data(self, depth):
-        width = opts.IM_WIDTH
+        width = opts.get_shape("W")
         left, right = depth[:, :width], depth[:, width:]
         return [left, right]
 

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -1,0 +1,65 @@
+import numpy as np
+from tfrecords.readers.waymo_reader import WaymoReader
+
+
+class ExampleMaker:
+    def __init__(self, dataset, split, shwc_shape, data_keys):
+        self.split = split
+        self.shwc_shape = shwc_shape
+        self.data_keys = data_keys
+        self.data_reader = self.get_data_reader(dataset, split)
+
+    def get_data_reader(self, dataset, split):
+        if dataset is "waymo":
+            return WaymoReader(split)
+        else:
+            assert 0, f"[get_data_reader] invalid dataset name {dataset}"
+
+    def list_frames_(self, drive_path):
+        self.data_reader.init_drive(drive_path)
+
+    def num_frames(self):
+        self.data_reader.num_frames()
+
+    def get_example(self, index):
+        frame_ids = self.make_snippet_ids(index)
+        example = dict()
+        example["image"] = self.load_snippet_images(frame_ids)
+        example["intrinsic"] = self.data_reader.get_intrinsic(index)
+        raw_shape_hwc = example["image"].shape
+        if "depth_gt" in self.data_keys:
+            example["depth_gt"] = self.data_reader.get_depth(index, raw_shape_hwc[:2], self.shwc_shape[1:3])
+        if "pose_gt" in self.data_keys:
+            example["pose_gt"] = self.load_snippet_poses(frame_ids)
+        if "image_R" in self.data_keys:
+            example["image_R"] = self.load_snippet_images(frame_ids, right=True)
+        if "intrinsic_R" in self.data_keys:
+            example["intrinsic_R"] = self.data_reader.get_intrinsic(index, right=True)
+        if "pose_gt_R" in self.data_keys:
+            example["pose_gt_R"] = self.load_snippet_poses(frame_ids, right=True)
+        if "stereo_T_LR" in self.data_keys:
+            example["stereo_T_LR"] = self.data_reader.get_stereo_extrinsic()
+
+    def make_snippet_ids(self, frame_index):
+        frame_id = self.data_reader.index_to_id(frame_index)
+        halflen = self.shwc_shape[0] // 2
+        max_frame_index = self.data_reader.num_frames() - 1
+        frame_seq_ids = np.arange(frame_id-halflen, frame_id+halflen+1)
+        frame_seq_ids = np.clip(frame_seq_ids, 0, max_frame_index).tolist()
+        return frame_seq_ids
+
+    def load_snippet_images(self, frame_ids, right=False):
+        image_seq = []
+        for fid in frame_ids:
+            image = self.data_reader.get_image(fid, right=right)
+            image_seq.append(image)
+        image_seq = np.concatenate(image_seq, axis=0)
+        return image_seq
+
+    def load_snippet_poses(self, frame_ids, right=False):
+        pose_seq = []
+        for fid in frame_ids:
+            pose = self.data_reader.get_pose(fid, right=right)
+            pose_seq.append(pose)
+        pose_seq = np.stack(pose_seq, axis=0)
+        return pose_seq

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -1,65 +1,107 @@
 import numpy as np
+import cv2
+
 from tfrecords.readers.waymo_reader import WaymoReader
 
 
 class ExampleMaker:
     def __init__(self, dataset, split, shwc_shape, data_keys):
+        self.dataset = dataset
         self.split = split
         self.shwc_shape = shwc_shape
         self.data_keys = data_keys
-        self.data_reader = self.get_data_reader(dataset, split)
+        self.data_reader = WaymoReader()
 
-    def get_data_reader(self, dataset, split):
-        if dataset is "waymo":
-            return WaymoReader(split)
-        else:
-            assert 0, f"[get_data_reader] invalid dataset name {dataset}"
-
-    def list_frames_(self, drive_path):
+    def init_reader(self, drive_path):
+        self.data_reader = self.get_data_reader()
         self.data_reader.init_drive(drive_path)
 
+    def get_data_reader(self):
+        if self.dataset is "waymo":
+            return WaymoReader(self.split)
+        else:
+            assert 0, f"[get_data_reader] invalid dataset name {self.dataset}"
+
     def num_frames(self):
-        self.data_reader.num_frames()
+        return self.data_reader.num_frames_()
+
+    def get_range(self):
+        return self.data_reader.get_range_()
 
     def get_example(self, index):
         frame_ids = self.make_snippet_ids(index)
         example = dict()
-        example["image"] = self.load_snippet_images(frame_ids)
-        example["intrinsic"] = self.data_reader.get_intrinsic(index)
-        raw_shape_hwc = example["image"].shape
+        example["image"], raw_shape_hwc = self.load_snippet_images(frame_ids)
+        example["intrinsic"] = self.load_intrinsic(index, raw_shape_hwc)
         if "depth_gt" in self.data_keys:
-            example["depth_gt"] = self.data_reader.get_depth(index, raw_shape_hwc[:2], self.shwc_shape[1:3])
+            example["depth_gt"] = self.data_reader.get_depth(index, raw_shape_hwc[:2],
+                                                             self.shwc_shape[1:3], example["intrinsic"])
         if "pose_gt" in self.data_keys:
             example["pose_gt"] = self.load_snippet_poses(frame_ids)
         if "image_R" in self.data_keys:
-            example["image_R"] = self.load_snippet_images(frame_ids, right=True)
+            example["image_R"], _ = self.load_snippet_images(frame_ids, right=True)
         if "intrinsic_R" in self.data_keys:
-            example["intrinsic_R"] = self.data_reader.get_intrinsic(index, right=True)
+            example["intrinsic_R"] = self.load_intrinsic(index, raw_shape_hwc, right=True)
         if "pose_gt_R" in self.data_keys:
             example["pose_gt_R"] = self.load_snippet_poses(frame_ids, right=True)
         if "stereo_T_LR" in self.data_keys:
             example["stereo_T_LR"] = self.data_reader.get_stereo_extrinsic()
 
+        if index % 100 == 10:
+            self.show_example(example, 200)
+        return example
+
     def make_snippet_ids(self, frame_index):
         frame_id = self.data_reader.index_to_id(frame_index)
         halflen = self.shwc_shape[0] // 2
-        max_frame_index = self.data_reader.num_frames() - 1
+        max_frame_index = self.num_frames() - 1
         frame_seq_ids = np.arange(frame_id-halflen, frame_id+halflen+1)
         frame_seq_ids = np.clip(frame_seq_ids, 0, max_frame_index).tolist()
         return frame_seq_ids
 
     def load_snippet_images(self, frame_ids, right=False):
         image_seq = []
+        raw_shape = self.shwc_shape[1:]
         for fid in frame_ids:
             image = self.data_reader.get_image(fid, right=right)
+            raw_shape = image.shape
+            dstsize_wh = (self.shwc_shape[2], self.shwc_shape[1])
+            image = cv2.resize(image, dstsize_wh)
             image_seq.append(image)
+        # move target image to the bottom
+        target_index = self.shwc_shape[0] // 2
+        target_image = image_seq.pop(target_index)
+        image_seq.append(target_image)
         image_seq = np.concatenate(image_seq, axis=0)
-        return image_seq
+        return image_seq, raw_shape
+
+    def load_intrinsic(self, index, raw_shape_hwc, right=False):
+        intrinsic = self.data_reader.get_intrinsic(index, right=right)
+        scale_y = self.shwc_shape[1] / raw_shape_hwc[0]
+        scale_x = self.shwc_shape[2] / raw_shape_hwc[1]
+        intrinsic[0] = intrinsic[0] * scale_x
+        intrinsic[1] = intrinsic[1] * scale_y
+        return intrinsic
 
     def load_snippet_poses(self, frame_ids, right=False):
         pose_seq = []
         for fid in frame_ids:
             pose = self.data_reader.get_pose(fid, right=right)
             pose_seq.append(pose)
+        target_index = self.shwc_shape[0] // 2
+        target_pose = pose_seq.pop(target_index)
+        pose_seq = [np.linalg.inv(pose) @ target_pose for pose in pose_seq]
         pose_seq = np.stack(pose_seq, axis=0)
         return pose_seq
+
+    def show_example(self, example, wait=0):
+        image = example["image"]
+        view = cv2.resize(image, (int(image.shape[1] * 1000. / image.shape[0]), 1000))
+        cv2.imshow("image", view)
+        cv2.waitKey(wait)
+        # print("\nintrinsic:\n", example["intrinsic"])
+        # if "pose_gt" in example:
+        #     print("pose\n", example["pose_gt"])
+
+
+

--- a/tfrecords/readers/reader_base.py
+++ b/tfrecords/readers/reader_base.py
@@ -19,9 +19,15 @@ class DataReaderBase:
         """
         raise NotImplementedError()
 
-    def num_frames(self):
+    def num_frames_(self):
         """
         :return: number of frames of the drive
+        """
+        raise NotImplementedError()
+
+    def get_range_(self):
+        """
+        :return: range object for frame index
         """
         raise NotImplementedError()
 

--- a/tfrecords/readers/reader_base.py
+++ b/tfrecords/readers/reader_base.py
@@ -1,34 +1,21 @@
 
 class DataReaderBase:
-    def __init__(self, base_path, drive_path, stereo=False):
+    def __init__(self, split):
         """
-        :param base_path: root path of dataset
-        :param drive_path: sequence drectory path
         when 'stereo' is True, 'get_xxx' function returns two data in tuple
         """
-        self.base_path = base_path
-        self.drive_path = drive_path
-        self.stereo = stereo
-        self.split = ""
-        self.frame_count = [0, 0]
+        self.split = split
         self.frame_names = []
         self.intrinsic = None
         self.T_left_right = None
-        self.static_frames = []
 
     """
     Public methods used outside this class
     """
-    def init_drive(self):
-        """
-        reset variables for a new sequence like intrinsic, extrinsic, and last index
-        """
-        raise NotImplementedError()
-
-    def list_frames(self, drive_path):
+    def init_drive(self, drive_path):
         """
         :param drive_path: path to data of a drive
-        :return: list of frame names and indices
+        reset variables for a new sequence like intrinsic, extrinsic, and last index
         """
         raise NotImplementedError()
 
@@ -38,25 +25,25 @@ class DataReaderBase:
         """
         raise NotImplementedError()
 
-    def get_image(self, index):
+    def get_image(self, index, right=False):
         """
-        :return: indexed image in the current sequence
+        :return: 'undistorted' indexed image in the current sequence
         """
         raise NotImplementedError()
 
-    def get_quat_pose(self, index):
+    def get_pose(self, index, right=False):
+        """
+        :return: indexed pose in matrix format
+        """
+        raise NotImplementedError()
+
+    def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
         """
         :return: indexed pose in a vector [position, quaternion] in the current sequence
         """
         raise NotImplementedError()
 
-    def get_depth_map(self, index, raw_img_shape=None, target_shape=None):
-        """
-        :return: indexed pose in a vector [position, quaternion] in the current sequence
-        """
-        raise NotImplementedError()
-
-    def get_intrinsic(self):
+    def get_intrinsic(self, index=0, right=False):
         """
         :return: camera projection matrix in the current sequence
         """
@@ -68,8 +55,17 @@ class DataReaderBase:
         """
         raise NotImplementedError()
 
-    def get_filename(self, example_index):
+    def get_filename(self, index):
         """
         :return: indexed frame file name
         """
         raise NotImplementedError()
+
+    def index_to_id(self, index):
+        """
+        :return: convert index of self.frame_names to frame id
+        """
+        # normally id is the same as index
+        return index
+
+

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -1,0 +1,245 @@
+import os
+import os.path as op
+from glob import glob
+import json
+import numpy as np
+from scipy import sparse
+import cv2
+import tensorflow as tf
+from waymo_open_dataset.utils import frame_utils
+from waymo_open_dataset import dataset_pb2 as open_dataset
+
+from tfrecords.readers.reader_base import DataReaderBase
+
+T_C2V = tf.constant([[0, 0, 1, 0], [-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]], dtype=tf.float32)
+FRONT_IND = 0
+
+
+class WaymoReader(DataReaderBase):
+    def __init__(self, split=""):
+        super().__init__(split)
+        self.tfr_dataset = None
+        self.frame_buffer = dict()
+        self.frame_count = 0
+
+    """
+    Public methods used outside this class
+    """
+    def init_drive(self, drive_path):
+        """
+        prepare variables to read a new sequence data
+        """
+        self.tfr_dataset = self._get_dataset(drive_path)
+        self.tfr_dataset = iter(self.tfr_dataset)
+        # self.frame_names =
+        # self.intrinsic =
+        # self.T_left_right =
+
+    def num_frames(self):
+        return 50000
+
+    def get_image(self, index, right=False):
+        assert right is False, "waymo dataset is monocular"
+        frame = self._get_frame(index)
+        front_image = tf.image.decode_jpeg(frame.images[0].image)
+        front_image = front_image.numpy()[:, :, [2, 1, 0]]  # rgb to bgr
+        return front_image
+
+    def get_pose(self, index, right=False):
+        assert right is False, "waymo dataset is monocular"
+        frame = self._get_frame(index)
+        pose_c2w = tf.reshape(frame.images[0].pose.transform, (4, 4)) @ T_C2V
+        return pose_c2w
+
+    def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
+        assert right is False, "waymo dataset is monocular"
+        return depth
+
+    def get_intrinsic(self, index=0, right=False):
+        assert right is False, "waymo dataset is monocular"
+        frame = self._get_frame(index)
+        intrin = frame.context.camera_calibrations[0].intrinsic
+        intrin = np.array([[intrin[0], 0, intrin[2]], [0, intrin[1], intrin[3]], [0, 0, 1]])
+        return intrin
+
+    def get_stereo_extrinsic(self):
+        return self.T_left_right
+
+    def get_filename(self, example_index):
+        filename = op.basename(self.frame_names[example_index])
+        return filename.split("_")[-1]
+
+    def list_frames(self, drive_path):
+        """
+        :param drive_path: sequence path like "train/bochum/bochum_000000"
+        :return frame_files: list of frame paths like ["train/bochum/bochum_000000_000001"]
+        """
+        frame_pattern = self._make_file_path(self.left_img_dir, drive_path + "_*", "png")
+        frame_files = glob(frame_pattern)
+        split_city = op.dirname(drive_path)
+        # list of ["city_seqind_frameid"]
+        frame_files = ["_".join(op.basename(file).split("_")[:-1]) for file in frame_files]
+        # list of ["split/city/city_seqind_frameid"]
+        frame_files = [op.join(split_city, file) for file in frame_files]
+        frame_files.sort()
+        frame_indices = [int(file.split("_")[-1]) for file in frame_files]
+        return frame_files
+
+    """
+    Private methods used inside this class
+    """
+    def _get_dataset(self, drive_path):
+        filenames = tf.io.gfile.glob(f"{drive_path}/*.tfrecord")
+        print("[tfrecord reader]", drive_path, filenames)
+        dataset = tf.data.TFRecordDataset(filenames, compression_type='')
+        return dataset
+
+    def _get_frame(self, index):
+        if index in self.frame_buffer:
+            return self.frame_buffer[index]
+
+        if index == self.frame_count + 1:
+            # add a new frame
+            frame_data = self.tfr_dataset.__next__()
+            frame = open_dataset.Frame()
+            frame.ParseFromString(bytearray(frame_data.numpy()))
+            self.frame_buffer[index] = frame
+            # remove an old frame
+            if index - 20 in self.frame_buffer:
+                self.frame_buffer.pop(index - 20, None)
+            return frame
+
+        assert 0, f"frame index is not consecutive: {self.frame_count} to {index}"
+
+    def _find_camera_matrix(self):
+        drive_path = "_".join(self.frame_names[0].split("_")[:-1])
+        # e.g. file_pattern = /path/to/cityscapes/camera/train/bochum/bochum_000000_*_camera.png
+        file_pattern = self._make_file_path("camera", drive_path + "_*", "json", False)
+        json_files = glob(file_pattern)
+        assert json_files, "[_find_camera_matrix] There is no json file in pattern: " + file_pattern
+        with open(json_files[0], "r") as fr:
+            camera_params = json.load(fr)
+        intrinsic = camera_params["intrinsic"]
+        fx, fy = intrinsic["fx"], intrinsic["fy"]
+        cx, cy = intrinsic["u0"], intrinsic["v0"]
+        K = np.array([[fx, 0., cx],
+                      [0., fy, cy],
+                      [0., 0., 1.]])
+        return K
+
+    def _read_depth_map(self, filename, target_shape):
+        image = cv2.imread(filename, cv2.IMREAD_ANYDEPTH)
+        assert image is not None, f"[_read_depth_map] There is no disparity image " + op.basename(filename)
+        disparity = (image.astype(np.float32) - 1.) / 256.
+        depth = np.where(image > 0., disparity, 0)
+        depth = cv2.resize(depth, (target_shape[1], target_shape[0]), cv2.INTER_NEAREST)
+        return depth
+
+    def _make_file_path(self, data_dir, frame_name, extension, add_suffix=True):
+        if add_suffix:
+            dir_name = data_dir + self.dir_suffix
+        else:
+            dir_name = data_dir
+        return op.join(self.base_path, dir_name, frame_name + f"_{data_dir}.{extension}")
+
+
+def get_depth_map_manually_project(frame, srcshape_hw, dstshape_hw, intrinsic):
+    (range_images, camera_projections, range_image_top_pose) = \
+        frame_utils.parse_range_image_and_camera_projection(frame)
+
+    points, cp_points = frame_utils.convert_range_image_to_point_cloud(
+        frame,
+        range_images,
+        camera_projections,
+        range_image_top_pose)
+
+    # xyz points in vehicle frame
+    points_veh = np.concatenate(points, axis=0)
+    # cp_points: (Nx6) [cam_id, ix, iy, cam_id, ix, iy]
+    cp_points = np.concatenate(cp_points, axis=0)[:, :3]
+    print("points all:", points_veh.shape, "cp_points", cp_points.shape)
+
+    # extract LiDAR points projected to camera[FRONT_IND]
+    camera_mask = np.equal(cp_points[:, 0], frame.images[FRONT_IND].name)
+    points_veh = points_veh[camera_mask]
+    cp_points = cp_points[camera_mask, 1:3]
+    print("cam1 points all:", points_veh.shape, "cam1 cp_points", cp_points.shape)
+
+    # transform points from vehicle to camera1
+    cam1_T_C2V = tf.reshape(frame.context.camera_calibrations[0].extrinsic.transform, (4, 4)).numpy()
+    cam1_T_V2C = np.linalg.inv(cam1_T_C2V)
+    points_veh_homo = np.concatenate((points_veh, np.ones((points_veh.shape[0], 1))), axis=1)
+    points_veh_homo = points_veh_homo.T
+    points_cam_homo = cam1_T_V2C @ points_veh_homo
+    points_depth = points_cam_homo[0]
+
+    # project points into image
+    # normalize depth to 1
+    points_cam = points_cam_homo[:3]
+    points_cam_norm = points_cam / points_cam[0:1]
+    # scale intrinsic parameters
+    scale_y, scale_x = (dstshape_hw[0] / srcshape_hw[0], dstshape_hw[1] / srcshape_hw[1])
+    # 3D Y axis = left = -image x,  ix = -Y*fx + cx
+    image_x = -points_cam_norm[1] * intrinsic[0, 0] * scale_x + intrinsic[0, 2] * scale_x
+    # 3D Z axis = up = -image y,  iy = -Z*fy + cy
+    image_y = -points_cam_norm[2] * intrinsic[1, 1] * scale_y + intrinsic[1, 2] * scale_y
+
+    # extract pixels in valid range
+    valid_mask = (image_x >= 0) & (image_x <= dstshape_hw[1] - 1) & (image_y >= 0) & (image_y <= dstshape_hw[0] - 1)
+    image_x = image_x[valid_mask].astype(np.int32)
+    image_y = image_y[valid_mask].astype(np.int32)
+    points_depth = points_depth[valid_mask]
+
+    # reconstruct depth map
+    depth_map = sparse.coo_matrix((points_depth, (image_y, image_x)), dstshape_hw)
+    depth_map = depth_map.toarray()
+    return depth_map
+
+
+def get_depth_map_use_cp(frame, srcshape_hw, dstshape_hw, intrinsic):
+    (range_images, camera_projections, range_image_top_pose) = \
+        frame_utils.parse_range_image_and_camera_projection(frame)
+
+    points, cp_points = frame_utils.convert_range_image_to_point_cloud(
+        frame,
+        range_images,
+        camera_projections,
+        range_image_top_pose)
+
+    # xyz points in vehicle frame
+    points_veh = np.concatenate(points, axis=0)
+    # cp_points: (Nx6) [cam_id, ix, iy, cam_id, ix, iy]
+    cp_points = np.concatenate(cp_points, axis=0)[:, :3]
+    print("points all:", points_veh.shape, "cp_points", cp_points.shape)
+
+    # extract LiDAR points projected to camera[FRONT_IND]
+    camera_mask = np.equal(cp_points[:, 0], frame.images[FRONT_IND].name)
+    points_veh = points_veh[camera_mask]
+    cp_points = cp_points[camera_mask, 1:3]
+    print("cam1 points all:", points_veh.shape, "cam1 cp_points", cp_points.shape)
+
+    # transform points from vehicle to camera1
+    cam1_T_C2V = tf.reshape(frame.context.camera_calibrations[0].extrinsic.transform, (4, 4)).numpy()
+    cam1_T_V2C = np.linalg.inv(cam1_T_C2V)
+    points_veh_homo = np.concatenate((points_veh, np.ones((points_veh.shape[0], 1))), axis=1)
+    points_veh_homo = points_veh_homo.T
+    points_cam_homo = cam1_T_V2C @ points_veh_homo
+    points_depth = points_cam_homo[0]
+
+    # scale parameters
+    scale_y, scale_x = (dstshape_hw[0] / srcshape_hw[0], dstshape_hw[1] / srcshape_hw[1])
+    image_x = cp_points[:, 0] * scale_x
+    image_y = cp_points[:, 1] * scale_y
+    # extract pixels in valid range
+    valid_mask = (image_x >= 0) & (image_x <= dstshape_hw[1] - 1) & (image_y >= 0) & (image_y <= dstshape_hw[0] - 1)
+    image_x = image_x[valid_mask].astype(np.int32)
+    image_y = image_y[valid_mask].astype(np.int32)
+    points_depth = points_depth[valid_mask]
+
+    # reconstruct depth map
+    depth_map = sparse.coo_matrix((points_depth, (image_y, image_x)), dstshape_hw)
+    depth_map = depth_map.toarray()
+    return depth_map
+
+
+

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -1,10 +1,6 @@
-import os
 import os.path as op
-from glob import glob
-import json
 import numpy as np
 from scipy import sparse
-import cv2
 import tensorflow as tf
 from waymo_open_dataset.utils import frame_utils
 from waymo_open_dataset import dataset_pb2 as open_dataset
@@ -20,7 +16,7 @@ class WaymoReader(DataReaderBase):
         super().__init__(split)
         self.tfr_dataset = None
         self.frame_buffer = dict()
-        self.frame_count = 0
+        self.latest_index = -1
 
     """
     Public methods used outside this class
@@ -31,66 +27,56 @@ class WaymoReader(DataReaderBase):
         """
         self.tfr_dataset = self._get_dataset(drive_path)
         self.tfr_dataset = iter(self.tfr_dataset)
+        self.latest_index = -1
         # self.frame_names =
         # self.intrinsic =
         # self.T_left_right =
 
-    def num_frames(self):
+    def num_frames_(self):
         return 50000
+
+    def get_range_(self):
+        return range(2, self.num_frames_()-2)
 
     def get_image(self, index, right=False):
         assert right is False, "waymo dataset is monocular"
         frame = self._get_frame(index)
         front_image = tf.image.decode_jpeg(frame.images[0].image)
         front_image = front_image.numpy()[:, :, [2, 1, 0]]  # rgb to bgr
-        return front_image
+        return front_image.astype(np.uint8)
 
     def get_pose(self, index, right=False):
         assert right is False, "waymo dataset is monocular"
         frame = self._get_frame(index)
         pose_c2w = tf.reshape(frame.images[0].pose.transform, (4, 4)) @ T_C2V
-        return pose_c2w
+        pose_c2w = pose_c2w.numpy()
+        return pose_c2w.astype(np.float32)
 
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
         assert right is False, "waymo dataset is monocular"
-        return depth
+        frame = self._get_frame(index)
+        depth = get_waymo_depth_map(frame, srcshape_hw, dstshape_hw, intrinsic)
+        return depth.astype(np.float32)
 
     def get_intrinsic(self, index=0, right=False):
         assert right is False, "waymo dataset is monocular"
         frame = self._get_frame(index)
         intrin = frame.context.camera_calibrations[0].intrinsic
         intrin = np.array([[intrin[0], 0, intrin[2]], [0, intrin[1], intrin[3]], [0, 0, 1]])
-        return intrin
+        return intrin.astype(np.float32)
 
     def get_stereo_extrinsic(self):
-        return self.T_left_right
+        return None
 
     def get_filename(self, example_index):
-        filename = op.basename(self.frame_names[example_index])
-        return filename.split("_")[-1]
-
-    def list_frames(self, drive_path):
-        """
-        :param drive_path: sequence path like "train/bochum/bochum_000000"
-        :return frame_files: list of frame paths like ["train/bochum/bochum_000000_000001"]
-        """
-        frame_pattern = self._make_file_path(self.left_img_dir, drive_path + "_*", "png")
-        frame_files = glob(frame_pattern)
-        split_city = op.dirname(drive_path)
-        # list of ["city_seqind_frameid"]
-        frame_files = ["_".join(op.basename(file).split("_")[:-1]) for file in frame_files]
-        # list of ["split/city/city_seqind_frameid"]
-        frame_files = [op.join(split_city, file) for file in frame_files]
-        frame_files.sort()
-        frame_indices = [int(file.split("_")[-1]) for file in frame_files]
-        return frame_files
+        return None
 
     """
     Private methods used inside this class
     """
     def _get_dataset(self, drive_path):
         filenames = tf.io.gfile.glob(f"{drive_path}/*.tfrecord")
-        print("[tfrecord reader]", drive_path, filenames)
+        print("[_get_dataset] read tfrecords in", op.basename(drive_path), filenames)
         dataset = tf.data.TFRecordDataset(filenames, compression_type='')
         return dataset
 
@@ -98,7 +84,7 @@ class WaymoReader(DataReaderBase):
         if index in self.frame_buffer:
             return self.frame_buffer[index]
 
-        if index == self.frame_count + 1:
+        if index == self.latest_index + 1:
             # add a new frame
             frame_data = self.tfr_dataset.__next__()
             frame = open_dataset.Frame()
@@ -107,43 +93,13 @@ class WaymoReader(DataReaderBase):
             # remove an old frame
             if index - 20 in self.frame_buffer:
                 self.frame_buffer.pop(index - 20, None)
+            self.latest_index = index
             return frame
 
-        assert 0, f"frame index is not consecutive: {self.frame_count} to {index}"
-
-    def _find_camera_matrix(self):
-        drive_path = "_".join(self.frame_names[0].split("_")[:-1])
-        # e.g. file_pattern = /path/to/cityscapes/camera/train/bochum/bochum_000000_*_camera.png
-        file_pattern = self._make_file_path("camera", drive_path + "_*", "json", False)
-        json_files = glob(file_pattern)
-        assert json_files, "[_find_camera_matrix] There is no json file in pattern: " + file_pattern
-        with open(json_files[0], "r") as fr:
-            camera_params = json.load(fr)
-        intrinsic = camera_params["intrinsic"]
-        fx, fy = intrinsic["fx"], intrinsic["fy"]
-        cx, cy = intrinsic["u0"], intrinsic["v0"]
-        K = np.array([[fx, 0., cx],
-                      [0., fy, cy],
-                      [0., 0., 1.]])
-        return K
-
-    def _read_depth_map(self, filename, target_shape):
-        image = cv2.imread(filename, cv2.IMREAD_ANYDEPTH)
-        assert image is not None, f"[_read_depth_map] There is no disparity image " + op.basename(filename)
-        disparity = (image.astype(np.float32) - 1.) / 256.
-        depth = np.where(image > 0., disparity, 0)
-        depth = cv2.resize(depth, (target_shape[1], target_shape[0]), cv2.INTER_NEAREST)
-        return depth
-
-    def _make_file_path(self, data_dir, frame_name, extension, add_suffix=True):
-        if add_suffix:
-            dir_name = data_dir + self.dir_suffix
-        else:
-            dir_name = data_dir
-        return op.join(self.base_path, dir_name, frame_name + f"_{data_dir}.{extension}")
+        assert 0, f"frame index is not consecutive: {self.latest_index} to {index}"
 
 
-def get_depth_map_manually_project(frame, srcshape_hw, dstshape_hw, intrinsic):
+def get_waymo_depth_map(frame, srcshape_hw, dstshape_hw, intrinsic):
     (range_images, camera_projections, range_image_top_pose) = \
         frame_utils.parse_range_image_and_camera_projection(frame)
 
@@ -157,13 +113,10 @@ def get_depth_map_manually_project(frame, srcshape_hw, dstshape_hw, intrinsic):
     points_veh = np.concatenate(points, axis=0)
     # cp_points: (Nx6) [cam_id, ix, iy, cam_id, ix, iy]
     cp_points = np.concatenate(cp_points, axis=0)[:, :3]
-    print("points all:", points_veh.shape, "cp_points", cp_points.shape)
 
     # extract LiDAR points projected to camera[FRONT_IND]
     camera_mask = np.equal(cp_points[:, 0], frame.images[FRONT_IND].name)
     points_veh = points_veh[camera_mask]
-    cp_points = cp_points[camera_mask, 1:3]
-    print("cam1 points all:", points_veh.shape, "cam1 cp_points", cp_points.shape)
 
     # transform points from vehicle to camera1
     cam1_T_C2V = tf.reshape(frame.context.camera_calibrations[0].extrinsic.transform, (4, 4)).numpy()
@@ -194,52 +147,3 @@ def get_depth_map_manually_project(frame, srcshape_hw, dstshape_hw, intrinsic):
     depth_map = sparse.coo_matrix((points_depth, (image_y, image_x)), dstshape_hw)
     depth_map = depth_map.toarray()
     return depth_map
-
-
-def get_depth_map_use_cp(frame, srcshape_hw, dstshape_hw, intrinsic):
-    (range_images, camera_projections, range_image_top_pose) = \
-        frame_utils.parse_range_image_and_camera_projection(frame)
-
-    points, cp_points = frame_utils.convert_range_image_to_point_cloud(
-        frame,
-        range_images,
-        camera_projections,
-        range_image_top_pose)
-
-    # xyz points in vehicle frame
-    points_veh = np.concatenate(points, axis=0)
-    # cp_points: (Nx6) [cam_id, ix, iy, cam_id, ix, iy]
-    cp_points = np.concatenate(cp_points, axis=0)[:, :3]
-    print("points all:", points_veh.shape, "cp_points", cp_points.shape)
-
-    # extract LiDAR points projected to camera[FRONT_IND]
-    camera_mask = np.equal(cp_points[:, 0], frame.images[FRONT_IND].name)
-    points_veh = points_veh[camera_mask]
-    cp_points = cp_points[camera_mask, 1:3]
-    print("cam1 points all:", points_veh.shape, "cam1 cp_points", cp_points.shape)
-
-    # transform points from vehicle to camera1
-    cam1_T_C2V = tf.reshape(frame.context.camera_calibrations[0].extrinsic.transform, (4, 4)).numpy()
-    cam1_T_V2C = np.linalg.inv(cam1_T_C2V)
-    points_veh_homo = np.concatenate((points_veh, np.ones((points_veh.shape[0], 1))), axis=1)
-    points_veh_homo = points_veh_homo.T
-    points_cam_homo = cam1_T_V2C @ points_veh_homo
-    points_depth = points_cam_homo[0]
-
-    # scale parameters
-    scale_y, scale_x = (dstshape_hw[0] / srcshape_hw[0], dstshape_hw[1] / srcshape_hw[1])
-    image_x = cp_points[:, 0] * scale_x
-    image_y = cp_points[:, 1] * scale_y
-    # extract pixels in valid range
-    valid_mask = (image_x >= 0) & (image_x <= dstshape_hw[1] - 1) & (image_y >= 0) & (image_y <= dstshape_hw[0] - 1)
-    image_x = image_x[valid_mask].astype(np.int32)
-    image_y = image_y[valid_mask].astype(np.int32)
-    points_depth = points_depth[valid_mask]
-
-    # reconstruct depth map
-    depth_map = sparse.coo_matrix((points_depth, (image_y, image_x)), dstshape_hw)
-    depth_map = depth_map.toarray()
-    return depth_map
-
-
-

--- a/tfrecords/test_reader.py
+++ b/tfrecords/test_reader.py
@@ -37,8 +37,9 @@ def test_tfrecord_reader():
 
 
 def create_model():
+    input_shape = (opts.get_shape("H")*5, opts.get_shape("W"), 3)
     model = Sequential([
-        Conv2D(16, 3, padding='same', activation='relu', input_shape=(opts.IM_HEIGHT*5, opts.IM_WIDTH, 3)),
+        Conv2D(16, 3, padding='same', activation='relu', input_shape=input_shape),
         MaxPooling2D(),
         Conv2D(32, 3, padding='same', activation='relu'),
         MaxPooling2D(),

--- a/tfrecords/tfr_util.py
+++ b/tfrecords/tfr_util.py
@@ -1,0 +1,73 @@
+import numpy as np
+import tensorflow as tf
+
+
+class Serializer:
+    def __call__(self, example_dict):
+        features = self.convert_to_feature(example_dict)
+        # wrap the data as TensorFlow Features.
+        features = tf.train.Features(feature=features)
+        # wrap again as a TensorFlow Example.
+        example = tf.train.Example(features=features)
+        # serialize the data.
+        serialized = example.SerializeToString()
+        return serialized
+
+    def convert_to_feature(self, example_dict):
+        features = dict()
+        for key, value in example_dict.items():
+            if isinstance(value, np.ndarray):
+                features[key] = self._bytes_feature(value.tostring())
+            elif isinstance(value, int):
+                features[key] = self._int64_feature(value)
+            elif isinstance(value, float):
+                features[key] = self._int64_feature(value)
+            else:
+                assert 0, f"[convert_to_feature] Wrong data type: {type(value)}"
+        return features
+
+    @staticmethod
+    def _bytes_feature(value):
+        """Returns a bytes_list from a string / byte."""
+        return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+    @staticmethod
+    def _float_feature(value):
+        """Returns a float_list from a float / double."""
+        return tf.train.Feature(float_list=tf.train.FloatList(value=[value]))
+
+    @staticmethod
+    def _int64_feature(value):
+        """Returns an int64_list from a bool / enum / int / uint."""
+        return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
+
+def inspect_properties(example):
+    config = dict()
+    for key, value in example.items():
+        config[key] = read_data_config(value)
+    return config
+
+
+def read_data_config(value):
+    parse_type = ""
+    decode_type = ""
+    shape = ()
+    if isinstance(value, np.ndarray):
+        if value.dtype == np.uint8:
+            decode_type = "tf.uint8"
+        elif value.dtype == np.float32:
+            decode_type = "tf.float32"
+        else:
+            assert 0, f"[FeederBase] Wrong numpy type: {value.dtype}"
+        parse_type = "tf.string"
+        shape = list(value.shape)
+    elif isinstance(value, int):
+        parse_type = "tf.int64"
+        shape = None
+    else:
+        assert 0, f"[FeederBase] Wrong type: {type(value)}"
+
+    return {"parse_type": parse_type, "decode_type": decode_type, "shape": shape}
+
+

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -1,0 +1,125 @@
+import os.path as op
+from glob import glob
+import tensorflow as tf
+import shutil
+import numpy as np
+import json
+
+import settings
+import utils.util_funcs as uf
+import utils.util_class as uc
+from tfrecords.example_maker import ExampleMaker
+
+
+DATASET_KEYS = {"kitti_raw": ["image", "intrinsic", "depth_gt", "pose_gt",
+                              "image_R", "intrinsic_R", "depth_gt_R", "pose_gt_R", "stereo_T_LR"],
+                "kitti_odom": ["image", "intrinsic", "pose_gt",
+                               "image_R", "intrinsic_R", "pose_gt_R", "stereo_T_LR"],
+                "cityscapes": ["image", "intrinsic", "depth_gt", "pose_gt"],
+                "waymo": ["image", "intrinsic", "depth_gt", "pose_gt"],
+                }
+
+
+class TfrecordMakerBase:
+    def __init__(self, dataset, split, srcpath, tfrpath, shard_size, stereo, shwc_shape):
+        self.dataset = dataset
+        self.split = split
+        self.srcpath = srcpath
+        self.tfrpath = tfrpath
+        self.shard_size = shard_size
+        self.stereo = stereo
+        self.shwc_shape = shwc_shape
+        self.example_count = 0
+        self.shard_count = 0
+        self.drive_paths = self.list_drives(srcpath, split)
+        self.data_keys = DATASET_KEYS[dataset]
+        self.example_maker = self.get_example_maker(dataset, split, srcpath, stereo, shwc_shape, self.data_keys)
+        self.writer = None
+        self.pm = uc.PathManager([""])
+
+    def list_drives(self, srcpath, split):
+        raise NotImplementedError()
+
+    def get_example_maker(self, *args):
+        return ExampleMaker(*args)
+
+    def make(self, max_frames=0):
+        stride = self.get_stride(max_frames)
+        num_drives = len(self.drive_paths)
+        with uc.PathManager(self.tfrpath) as pm:
+            self.pm = pm
+            for di, drive_path in enumerate(self.drive_paths):
+                if self.init_tfrecord(di):
+                    continue
+                # create data reader in example maker
+                self.example_maker.list_frames_(drive_path)
+                num_frames = self.example_maker.num_frames()
+                for index in range(0, num_frames, stride):
+                    example = self.example_maker.get_example(index)
+                    example_serial = self.serialize_example(example)
+                    if not example_serial:
+                        break
+
+                    self.write_tfrecord(example_serial)
+                    uf.print_progress_status(f"==[making TFR] drive: {di}/{num_drives}, frame: {index}/{num_frames}")
+            self.wrap_up()
+            pm.set_ok()
+
+    def get_stride(self, max_frames):
+        return 1
+
+    def init_tfrecord(self, drive_index=0):
+        raise NotImplementedError()
+
+    def serialize_example(self, example_dict):
+        # wrap the data as TensorFlow Features.
+        features = tf.train.Features(feature=example_dict)
+        # wrap again as a TensorFlow Example.
+        example = tf.train.Example(features=features)
+        # serialize the data.
+        serialized = example.SerializeToString()
+        return serialized
+
+    def write_tfrecord(self, example_serial):
+        self.writer.write(example_serial)
+        self.example_count += 1
+        # reset and create a new tfrecord file
+        if self.example_count > self.shard_size:
+            self.shard_count += 1
+            self.example_count = 0
+            self.init_tfrecord()
+
+    def wrap_up(self):
+        self.writer.close()
+
+
+class WaymoTfrecordMaker(TfrecordMakerBase):
+    def __init__(self, dataset, split, srcpath, tfrpath, shard_size, stereo, shwc_shape):
+        super().__init__(dataset, split, srcpath, tfrpath, shard_size, stereo, shwc_shape)
+
+    def list_drives(self, srcpath, split):
+        drive_paths = glob(op.join(srcpath, "training_*"))
+        drive_paths.sort()
+        return drive_paths
+
+    def init_tfrecord(self, drive_index=0):
+        outpath = f"{self.tfrpath}/drive_{drive_index:03d}"
+        if op.isdir(outpath):
+            print(f"[init_tfrecord] {outpath} exists. move onto the next")
+            return True
+
+        # change path to check date integrity
+        self.pm.reopen([outpath])
+        outfile = f"{outpath}/{self.dataset}_{self.split}_{drive_index:03d}_shard_{self.shard_count:03d}.tfrecord"
+        if self.writer is not None:
+            self.writer.close()
+        self.writer = tf.io.TFRecordWriter(outfile)
+        return False
+
+    def wrap_up(self):
+        self.writer.close()
+        files = glob(f"{self.tfrpath}/*/*.tfrecord")
+        for file in files:
+            shutil.move(file, op.join(self.tfrpath, op.basename(file)))
+
+

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -1,3 +1,4 @@
+import os
 import os.path as op
 from glob import glob
 import tensorflow as tf
@@ -9,15 +10,7 @@ import settings
 import utils.util_funcs as uf
 import utils.util_class as uc
 from tfrecords.example_maker import ExampleMaker
-
-
-DATASET_KEYS = {"kitti_raw": ["image", "intrinsic", "depth_gt", "pose_gt",
-                              "image_R", "intrinsic_R", "depth_gt_R", "pose_gt_R", "stereo_T_LR"],
-                "kitti_odom": ["image", "intrinsic", "pose_gt",
-                               "image_R", "intrinsic_R", "pose_gt_R", "stereo_T_LR"],
-                "cityscapes": ["image", "intrinsic", "depth_gt", "pose_gt"],
-                "waymo": ["image", "intrinsic", "depth_gt", "pose_gt"],
-                }
+from tfrecords.tfr_util import Serializer, inspect_properties
 
 
 class TfrecordMakerBase:
@@ -25,101 +18,177 @@ class TfrecordMakerBase:
         self.dataset = dataset
         self.split = split
         self.srcpath = srcpath
-        self.tfrpath = tfrpath
-        self.shard_size = shard_size
-        self.stereo = stereo
+        self.tfrpath = tfrpath              # final root path of tfrecords of this dataset
+        self.tfrpath__ = tfrpath + "__"     # temporary root path of tfrecords of this dataset
+        self.tfr_drive_path = tfrpath       # path to write "current" tfrecords
         self.shwc_shape = shwc_shape
-        self.example_count = 0
-        self.shard_count = 0
-        self.drive_paths = self.list_drives(srcpath, split)
-        self.data_keys = DATASET_KEYS[dataset]
-        self.example_maker = self.get_example_maker(dataset, split, srcpath, stereo, shwc_shape, self.data_keys)
+        self.shard_size = shard_size        # max number of examples in a shard
+        self.shard_count = 0                # number of shards written in this drive
+        self.example_count_in_shard = 0     # number of examples in this shard
+        self.example_count_in_drive = 0     # number of examples in this drive
+        self.drive_paths = self.list_drive_paths(srcpath, split)
+        self.data_keys = self.get_dataset_keys(dataset, split, stereo)
+        self.example_maker = self.get_example_maker(dataset, split, shwc_shape, self.data_keys)
+        self.serialize_example = Serializer()
         self.writer = None
         self.pm = uc.PathManager([""])
 
-    def list_drives(self, srcpath, split):
+    def list_drive_paths(self, srcpath, split):
         raise NotImplementedError()
+
+    def get_dataset_keys(self, dataset, split, stereo):
+        keys = []
+        if dataset is "kitti_raw":
+            keys = ["image", "intrinsic", "depth_gt", "pose_gt"]
+            if stereo:
+                keys += ["image_R", "intrinsic_R", "depth_gt_R", "pose_gt_R", "stereo_T_LR"]
+        elif dataset is "kitti_odom":
+            keys = ["image", "intrinsic", "pose_gt"] if split is "test" else ["image", "intrinsic"]
+            if stereo:
+                if split is "test":
+                    keys += ["image_R", "intrinsic_R", "pose_gt_R", "stereo_T_LR"]
+                else:
+                    keys += ["image_R", "intrinsic_R", "stereo_T_LR"]
+        elif dataset is "cityscapes":
+            keys = ["image", "intrinsic", "depth_gt", "pose_gt"]
+        elif dataset is "waymo":
+            keys = ["image", "intrinsic", "depth_gt", "pose_gt"]
+        else:
+            assert 0, f"[get_dataset_keys] Wrong dataset: {dataset}, {split}, {stereo}"
+        return keys
 
     def get_example_maker(self, *args):
         return ExampleMaker(*args)
 
     def make(self, max_frames=0):
-        stride = self.get_stride(max_frames)
         num_drives = len(self.drive_paths)
-        with uc.PathManager(self.tfrpath) as pm:
+        with uc.PathManager([self.tfrpath__], closer_func=self.on_exit) as pm:
             self.pm = pm
             for di, drive_path in enumerate(self.drive_paths):
+                if di > 3:
+                    break
                 if self.init_tfrecord(di):
                     continue
+
                 # create data reader in example maker
-                self.example_maker.list_frames_(drive_path)
+                self.example_maker.init_reader(drive_path)
                 num_frames = self.example_maker.num_frames()
-                for index in range(0, num_frames, stride):
+                loop_range = self.example_maker.get_range()
+
+                last_example = dict()
+                for index in loop_range:
                     example = self.example_maker.get_example(index)
+                    if example is None:     # if example was empty, this drive ended
+                        break
+                    elif not example:       # when dict is empty, skip this index
+                        continue
                     example_serial = self.serialize_example(example)
-                    if not example_serial:
+                    if index > 50:
                         break
 
-                    self.write_tfrecord(example_serial)
+                    last_example = example
+                    self.write_tfrecord(example_serial, di)
                     uf.print_progress_status(f"==[making TFR] drive: {di}/{num_drives}, frame: {index}/{num_frames}")
-            self.wrap_up()
-            pm.set_ok()
+                self.write_tfrecord_config(last_example)
 
-    def get_stride(self, max_frames):
-        return 1
+            pm.set_ok()
+        self.wrap_up()
 
     def init_tfrecord(self, drive_index=0):
         raise NotImplementedError()
 
-    def serialize_example(self, example_dict):
-        # wrap the data as TensorFlow Features.
-        features = tf.train.Features(feature=example_dict)
-        # wrap again as a TensorFlow Example.
-        example = tf.train.Example(features=features)
-        # serialize the data.
-        serialized = example.SerializeToString()
-        return serialized
-
-    def write_tfrecord(self, example_serial):
+    def write_tfrecord(self, example_serial, drive_index):
         self.writer.write(example_serial)
-        self.example_count += 1
+        self.example_count_in_shard += 1
+        self.example_count_in_drive += 1
         # reset and create a new tfrecord file
-        if self.example_count > self.shard_size:
+        if self.example_count_in_shard > self.shard_size:
             self.shard_count += 1
-            self.example_count = 0
-            self.init_tfrecord()
+            self.example_count_in_shard = 0
+            self.open_new_writer(drive_index)
+
+    def open_new_writer(self, drive_index):
+        raise NotImplementedError()
+
+    def write_tfrecord_config(self, example):
+        raise NotImplementedError()
+
+    def on_exit(self):
+        if self.writer:
+            self.writer.close()
+            self.writer = None
 
     def wrap_up(self):
-        self.writer.close()
+        raise NotImplementedError()
 
 
 class WaymoTfrecordMaker(TfrecordMakerBase):
     def __init__(self, dataset, split, srcpath, tfrpath, shard_size, stereo, shwc_shape):
         super().__init__(dataset, split, srcpath, tfrpath, shard_size, stereo, shwc_shape)
 
-    def list_drives(self, srcpath, split):
-        drive_paths = glob(op.join(srcpath, "training_*"))
+    def list_drive_paths(self, srcpath, split):
+        # drive_paths = glob(op.join(srcpath, "training_*"))
+        drive_paths = []
+        if self.split is "train":
+            BAD_DRIVES = [2, 4, 5, 10, 11, 12, 17, 25]
+        else:
+            BAD_DRIVES = [2, 4, 5, 10, 11, 12, 17, 25]
+        for di in range(28):
+            if di in BAD_DRIVES:
+                continue
+            drive = op.join(srcpath, f"training_{di:04d}")
+            drive_paths.append(drive)
         drive_paths.sort()
         return drive_paths
 
     def init_tfrecord(self, drive_index=0):
-        outpath = f"{self.tfrpath}/drive_{drive_index:03d}"
+        outpath = f"{self.tfrpath__}/drive_{drive_index:03d}"
         if op.isdir(outpath):
-            print(f"[init_tfrecord] {outpath} exists. move onto the next")
+            print(f"[init_tfrecord] {op.basename(outpath)} exists. move onto the next")
             return True
 
         # change path to check date integrity
-        self.pm.reopen([outpath])
-        outfile = f"{outpath}/{self.dataset}_{self.split}_{drive_index:03d}_shard_{self.shard_count:03d}.tfrecord"
-        if self.writer is not None:
-            self.writer.close()
-        self.writer = tf.io.TFRecordWriter(outfile)
+        self.pm.reopen([outpath], closer_func=self.on_exit)
+        self.tfr_drive_path = outpath
+        self.shard_count = 0
+        self.example_count_in_shard = 0
+        self.example_count_in_drive = 0
+        self.open_new_writer(drive_index)
         return False
 
+    def open_new_writer(self, drive_index):
+        outfile = f"{self.tfr_drive_path}/{drive_index:03d}_shard_{self.shard_count:03d}.tfrecord"
+        self.writer = tf.io.TFRecordWriter(outfile)
+
+    def write_tfrecord_config(self, example):
+        config = inspect_properties(example)
+        config["length"] = self.example_count_in_drive
+        config["imshape"] = self.shwc_shape
+        print("## save config", config)
+        with open(op.join(self.tfr_drive_path, "tfr_config.txt"), "w") as fr:
+            json.dump(config, fr)
+
     def wrap_up(self):
-        self.writer.close()
-        files = glob(f"{self.tfrpath}/*/*.tfrecord")
+        files = glob(f"{self.tfrpath__}/*/*.tfrecord")
+        print("[wrap_up] move tfrecords:", files[0:-1:5])
         for file in files:
-            shutil.move(file, op.join(self.tfrpath, op.basename(file)))
+            shutil.move(file, op.join(self.tfrpath__, op.basename(file)))
+
+        # merge config files of all drives and save only one in tfrpath
+        files = glob(f"{self.tfrpath__}/*/tfr_config.txt")
+        print("[wrap_up] config files:", files[:5])
+        print(f"{self.tfrpath__}/*/config.txt")
+        total_length = 0
+        config = dict()
+        for file in files:
+            with open(file, 'r') as fp:
+                config = json.load(fp)
+                total_length += config["length"]
+        config["length"] = total_length
+        with open(op.join(self.tfrpath__, "tfr_config.txt"), "w") as fr:
+            json.dump(config, fr)
+
+        os.rename(self.tfrpath__, self.tfrpath)
+
 
 

--- a/tfrecords/tfrecord_writer.py
+++ b/tfrecords/tfrecord_writer.py
@@ -140,7 +140,7 @@ class TfrecordMaker:
             if self.shuffle:
                 indices = np.random.permutation(len(file_list))
             else:
-                indices = np.arnage(len(file_list))
+                indices = np.arange(len(file_list))
             if self.max_frames:
                 indices = indices[:self.max_frames]
             new_list = [file_list[i] for i in indices]

--- a/utils/util_class.py
+++ b/utils/util_class.py
@@ -13,18 +13,20 @@ class WrongInputException(Exception):
 
 
 class PathManager:
-    def __init__(self, paths):
+    def __init__(self, paths, closer_func=None):
         self.paths = paths
         self.safe_exit = False
+        self.closer = closer_func
 
     def __enter__(self):
         for path in self.paths:
             os.makedirs(path, exist_ok=True)
         return self
 
-    def reopen(self, paths):
+    def reopen(self, paths, closer_func=None):
         self.paths = paths
         self.safe_exit = False
+        self.closer = closer_func
         for path in self.paths:
             os.makedirs(path, exist_ok=True)
         return self
@@ -33,6 +35,7 @@ class PathManager:
         self.safe_exit = True
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.closer()
         if self.safe_exit is False:
             print("[PathManager] the process is NOT ended properly, remove the working paths")
             for path in self.paths:

--- a/utils/util_class.py
+++ b/utils/util_class.py
@@ -19,8 +19,14 @@ class PathManager:
 
     def __enter__(self):
         for path in self.paths:
-            if path is not None:
-                os.makedirs(path, exist_ok=True)
+            os.makedirs(path, exist_ok=True)
+        return self
+
+    def reopen(self, paths):
+        self.paths = paths
+        self.safe_exit = False
+        for path in self.paths:
+            os.makedirs(path, exist_ok=True)
         return self
 
     def set_ok(self):

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -191,7 +191,7 @@ def multi_scale_like_flow(image, flow_ms):
 
 
 def stack_titled_images(view_imgs, guide_lines=True):
-    dsize = (opts.IM_HEIGHT, opts.IM_WIDTH)
+    dsize = opts.get_shape("HW")
     location = (20, 20)
     font = cv2.FONT_HERSHEY_SIMPLEX
     font_scale = 0.5


### PR DESCRIPTION

## config.py

IM_WIDTH, IM_HEGIHT 상수 없애고 데이터셋에 따라 다른 상수를 받아올 수 있는 get_shape() 함수 제공
get_shape()에서는 `B,S,H,W,C` 다섯 글자의 조합으로 만든 입력인자에 따라 원하는 shape을 받을 수 있음

## Kitti 데이터셋을 위한 prepare_data의 리팩터링

### prepare_data/data_factories.py

데이터 준비 과정에 필요한 클래스들을 생성하는 팩토리 함수들을 이곳으로 모음
example_maker_factory, drive_lister_factory, dataset_reader_factory

### list_drives.py

데이터셋의 drive_paths를 찾는 기능을 DataReaderBase의 자식 클래스에서 분리하여
데이터셋 별로 ListDrivesBase의 자식 클래스로 구현

### prepare_data/readers/xxx_readers.py

데이터셋의 drive_paths를 찾는 기능 제거

### prepare_data/readers/examine_waymo.py

waymo 데이터셋에서 3차원 점에 대한 픽셀 좌표를 
데이터셋에서 주어진 이미지 좌표를 쓸 것인지 (get_depth_map_use_cp)
직접 계산한 것을 쓸것인지를 (get_depth_map_manually_project) photometric loss를 비교하여 결정
비교 결과 직접 계산한 결과가 미세하게 낮아서 직접 계산한 결과 사용


## Waymo 데이터셋을 위한 tfrecord 모듈 수정

waymo 데이터셋은 prepare_data 과정을 거치지 않고 바로 tfrecord를 생성할수 있도록 전체적으로 재설계
- create_tfrecords_main: dataset과 split에서 반복, tfrecord_maker가 tfrecord를 만들게한다.
- tfrecord_maker: drive와 frame 단위에서 반복, example_maker를 이용해서 example을 받으면 이걸 serialize해서 tfrecord로 저장한다.
- example_maker: data_reader를 이용하여 tfrecord로 저장할 "example" 한 세트를 만든다.
- xxx_reader: 특정 데이터셋에서 image, depth, pose, intrinsic 등을 불러와준다.

### tfrecords/create_tfrecords_main.py

데이터셋에서 바로 tfrecord를 만들수 있는 (지금은 waymo만) convert_to_tfrecords_directly() 함수 구현

### tfrecords/example_maker.py

data_reader를 이용하여 tfrecord로 저장할 "example" 한 세트를 만든다.
ExampleMaker 클래스는 데이터셋 공용이다.

### tfrecords/readers

이 폴더 아래있는 모듈들은 특정 데이터셋에서 image, depth, pose, intrinsic 등을 불러와준다.
모두 DataReaderBase를 상속받아 같은 인터페이스를 공유한다.

### tfrecords/tfr_util.py

ExampleMaker에서 필요한 Serializer 클래스, inspect_properties(example) 함수를 제공한다.

### tfrecords/tfrecord_maker.py

ExampleMaker를 이용해서 example set을 dict로 받으면 이걸 serialize해서 tfrecord로 저장한다.
example이 너무 많으면 중간에 shard를 자른다.
데이터셋마다 TfrecordMakerBase의 자식 클래스를 만들어 바뀌는 부분을 채운다.
