### PR TITLE
Cityscapes tfrecords from zips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ __pycache__
 .idea
 config.py
 .python-version
-
+temp_*

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -123,7 +123,7 @@ def predict(weight_name="latest.h5"):
     model = try_load_weights(model, weight_name)
     model.compile(optimizer="sgd", loss="mean_absolute_error")
 
-    dataset, steps = get_dataset(opts.DATASET_TO_USE, "test", False, batch_size)
+    dataset, steps = get_dataset(opts.DATASET_TO_USE, "test", False)
     # [disp_s1, disp_s2, disp_s4, disp_s8, pose] = model.predict({"image": ...})
     # TODO: predict and collect outputs in for loop
     predictions = model.predict(dataset, steps)

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -32,7 +32,7 @@ def convert_to_tfrecords_directly():
     datasets = opts.DATASETS_TO_PREPARE
     for dataset, splits in datasets.items():
         for split in splits:
-            tfrpath = op.join(opts.DATAPATH_TFR, f"{dataset}_{split}")
+            tfrpath = op.join(opts.DATAPATH_TFR, f"{dataset.split('__')[0]}_{split}")
             if op.isdir(tfrpath):
                 print("[convert_to_tfrecords] tfrecord already created in", tfrpath)
                 continue
@@ -43,9 +43,11 @@ def convert_to_tfrecords_directly():
 
 
 def tfrecord_maker_factory(dataset, split, srcpath, tfrpath):
-    if dataset is "waymo":
-        return tm.WaymoTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO,
-                                     opts.get_shape("SHWC", dataset))
+    dstshape = opts.get_shape("SHWC", dataset.split('__')[0])
+    if dataset.startswith("cityscapes"):
+        return tm.CityscapesTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, False, dstshape)
+    elif dataset is "waymo":
+        return tm.WaymoTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
     else:
         WrongInputException(f"Invalid dataset: {dataset}")
 

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -2,25 +2,29 @@ import numpy as np
 import cv2
 
 from tfrecords.readers.waymo_reader import WaymoReader
+from tfrecords.readers.city_reader import CityReader
 
 
 class ExampleMaker:
-    def __init__(self, dataset, split, shwc_shape, data_keys):
+    def __init__(self, dataset, split, shwc_shape, data_keys, reader_args=None):
         self.dataset = dataset
         self.split = split
         self.shwc_shape = shwc_shape
         self.data_keys = data_keys
         self.data_reader = WaymoReader()
+        self.reader_args = reader_args
 
     def init_reader(self, drive_path):
-        self.data_reader = self.get_data_reader()
+        self.data_reader = self.data_reader_factory()
         self.data_reader.init_drive(drive_path)
 
-    def get_data_reader(self):
+    def data_reader_factory(self):
+        if self.dataset.startswith("cityscapes"):
+            return CityReader(self.split, self.reader_args)     # split and ZipFile object
         if self.dataset is "waymo":
             return WaymoReader(self.split)
         else:
-            assert 0, f"[get_data_reader] invalid dataset name {self.dataset}"
+            assert 0, f"[data_reader_factory] invalid dataset name {self.dataset}"
 
     def num_frames(self):
         return self.data_reader.num_frames_()
@@ -29,22 +33,22 @@ class ExampleMaker:
         return self.data_reader.get_range_()
 
     def get_example(self, index):
-        frame_ids = self.make_snippet_ids(index)
+        frame_id, frame_seq_ids = self.make_snippet_ids(index)
         example = dict()
-        example["image"], raw_shape_hwc = self.load_snippet_images(frame_ids)
-        example["intrinsic"] = self.load_intrinsic(index, raw_shape_hwc)
+        example["image"], raw_shape_hwc = self.load_snippet_images(frame_seq_ids)
+        example["intrinsic"] = self.load_intrinsic(frame_id, raw_shape_hwc)
         if "depth_gt" in self.data_keys:
-            example["depth_gt"] = self.load_depth_map(index, raw_shape_hwc)
+            example["depth_gt"] = self.load_depth_map(frame_id, raw_shape_hwc)
         if "pose_gt" in self.data_keys:
-            example["pose_gt"] = self.load_snippet_poses(frame_ids)
+            example["pose_gt"] = self.load_snippet_poses(frame_seq_ids)
         if "image_R" in self.data_keys:
-            example["image_R"], _ = self.load_snippet_images(frame_ids, right=True)
+            example["image_R"], _ = self.load_snippet_images(frame_seq_ids, right=True)
         if "intrinsic_R" in self.data_keys:
-            example["intrinsic_R"] = self.load_intrinsic(index, raw_shape_hwc, right=True)
+            example["intrinsic_R"] = self.load_intrinsic(frame_id, raw_shape_hwc, right=True)
         if "pose_gt_R" in self.data_keys:
-            example["pose_gt_R"] = self.load_snippet_poses(frame_ids, right=True)
+            example["pose_gt_R"] = self.load_snippet_poses(frame_seq_ids, right=True)
         if "stereo_T_LR" in self.data_keys:
-            example["stereo_T_LR"] = self.data_reader.get_stereo_extrinsic()
+            example["stereo_T_LR"] = self.data_reader.get_stereo_extrinsic(frame_id)
 
         if index % 100 == 10:
             self.show_example(example, 200)
@@ -62,7 +66,7 @@ class ExampleMaker:
         max_frame_index = self.num_frames() - 1
         frame_seq_ids = np.arange(frame_id-halflen, frame_id+halflen+1)
         frame_seq_ids = np.clip(frame_seq_ids, 0, max_frame_index).tolist()
-        return frame_seq_ids
+        return frame_id, frame_seq_ids
 
     def load_snippet_images(self, frame_ids, right=False):
         image_seq = []
@@ -79,7 +83,7 @@ class ExampleMaker:
         target_index = self.shwc_shape[0] // 2
         target_image = image_seq.pop(target_index)
         image_seq.append(target_image)
-        image_seq = np.concatenate(image_seq, axis=0)
+        image_seq = np.concatenate(image_seq, axis=0).astype(np.uint8)
         return image_seq, raw_shape
 
     def load_intrinsic(self, index, raw_shape_hwc, right=False):
@@ -90,7 +94,7 @@ class ExampleMaker:
         scale_x = self.shwc_shape[2] / raw_shape_hwc[1]
         intrinsic[0] = intrinsic[0] * scale_x
         intrinsic[1] = intrinsic[1] * scale_y
-        return intrinsic
+        return intrinsic.astype(np.float32)
 
     def load_snippet_poses(self, frame_ids, right=False):
         pose_seq = []
@@ -103,19 +107,21 @@ class ExampleMaker:
         target_pose = pose_seq.pop(target_index)
         pose_seq = [np.linalg.inv(pose) @ target_pose for pose in pose_seq]
         pose_seq = np.stack(pose_seq, axis=0)
-        return pose_seq
+        return pose_seq.astype(np.float32)
 
     def load_depth_map(self, index, raw_shape_hwc):
         intrinsic = self.data_reader.get_intrinsic(index)
         depth_map = self.data_reader.get_depth(index, raw_shape_hwc[:2], self.shwc_shape[1:3], intrinsic)
-        return depth_map
+        return depth_map.astype(np.float32)
 
     def show_example(self, example, wait=0):
         image = example["image"]
+        image_view = cv2.resize(image, (int(image.shape[1] * 1000. / image.shape[0]), 1000))
         depth = example["depth_gt"]
-        view = cv2.resize(image, (int(image.shape[1] * 1000. / image.shape[0]), 1000))
-        cv2.imshow("image", view)
-        cv2.imshow("depth", depth)
+        depth_view = (np.clip(depth, 0, 50.) / 50. * 256).astype(np.uint8)
+        depth_view = cv2.applyColorMap(depth_view, cv2.COLORMAP_SUMMER)
+        cv2.imshow("image", image_view)
+        cv2.imshow("depth", depth_view)
         cv2.waitKey(wait)
         # print("\nintrinsic:\n", example["intrinsic"])
         # if "pose_gt" in example:

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -117,11 +117,18 @@ class ExampleMaker:
     def show_example(self, example, wait=0):
         image = example["image"]
         image_view = cv2.resize(image, (int(image.shape[1] * 1000. / image.shape[0]), 1000))
+        cv2.imshow("image", image_view)
+
+        if "image_R" in example:
+            image = example["image_R"]
+            image_view = cv2.resize(image, (int(image.shape[1] * 1000. / image.shape[0]), 1000))
+            cv2.imshow("image_R", image_view)
+
         depth = example["depth_gt"]
         depth_view = (np.clip(depth, 0, 50.) / 50. * 256).astype(np.uint8)
         depth_view = cv2.applyColorMap(depth_view, cv2.COLORMAP_SUMMER)
-        cv2.imshow("image", image_view)
         cv2.imshow("depth", depth_view)
+
         cv2.waitKey(wait)
         # print("\nintrinsic:\n", example["intrinsic"])
         # if "pose_gt" in example:

--- a/tfrecords/readers/city_reader.py
+++ b/tfrecords/readers/city_reader.py
@@ -1,0 +1,203 @@
+import os.path as op
+import numpy as np
+from glob import glob
+from PIL import Image
+import json
+
+from tfrecords.readers.reader_base import DataReaderBase
+
+
+class CityReader(DataReaderBase):
+    def __init__(self, split="", reader_arg=None):
+        super().__init__(split)
+        self.zip_files = reader_arg
+        self.camera_names = []
+        self.cur_camera_param = dict()
+        self.cur_camera_index = -1
+        self.target_indices = []
+
+    """
+    Public methods used outside this class
+    """
+    def init_drive(self, drive_path):
+        """
+        prepare variables to read a new sequence data
+        """
+        self.frame_names = self.zip_files["leftimg"].namelist()
+        self.camera_names = self.zip_files["camera"].namelist()
+        self.frame_names = [frame for frame in self.frame_names if frame.startswith(drive_path)]
+        self.frame_names.sort()
+
+    def num_frames_(self):
+        return len(self.target_indices)
+
+    def get_range_(self):
+        # list sub drives like /leftImg8bit/train/aachen/aachen/aachen_000000
+        sub_drives = ["_".join(frame.split("_")[:-2]) for frame in self.frame_names]
+        sub_drives = list(set(sub_drives))
+        sub_drives.sort()
+        self.target_indices = []
+        for sub_drive in sub_drives:
+            sub_drive_indices = [fi for fi, frame in enumerate(self.frame_names) if frame.startswith(sub_drive)]
+            sub_drive_indices.sort()
+            # remove first and last two frames in sub-drives
+            sub_drive_indices = sub_drive_indices[2:-2]
+            if sub_drive_indices:
+                self.target_indices.extend(sub_drive_indices)
+
+        print("[get_range_] target_indices:", self.target_indices[20:40], self.target_indices[50:70])
+        return self.target_indices
+
+    def get_image(self, index, right=False):
+        assert right is False, "city dataset is monocular"
+        image_bytes = self.zip_files["leftimg"].open(self.frame_names[index])
+        image = Image.open(image_bytes)
+        image = np.array(image, np.uint8)
+        return image
+
+    def get_pose(self, index, right=False):
+        return None
+
+    def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
+        assert right is False, "city dataset is monocular"
+        params = self._get_camera_param(index)
+        baseline = params["extrinsic"]["baseline"]
+        fx = params["intrinsic"]["fx"]
+
+        disp_name = self.frame_names[index].replace("leftImg8bit", "disparity")
+        # disp_name = disp_name.replace("leftImg8bit", "disparity")
+        disp_bytes = self.zip_files["disparity"].open(disp_name)
+        disp = Image.open(disp_bytes)
+        disp = np.array(disp, np.uint16).astype(np.float32)
+        disp[disp > 0] = (disp[disp > 0] - 1) / 256.
+        depth = np.zeros(disp.shape, dtype=np.float32)
+        depth[disp > 0] = (fx * baseline) / disp[disp > 0]     # depth = baseline * focal length / disparity
+        depth = city_resize_depth_map(depth, srcshape_hw, dstshape_hw, intrinsic)
+        return depth.astype(np.float32)
+
+    def get_intrinsic(self, index=0, right=False):
+        assert right is False, "city dataset is monocular"
+        params = self._get_camera_param(index)
+        fx = params["intrinsic"]["fx"]
+        fy = params["intrinsic"]["fy"]
+        cx = params["intrinsic"]["u0"]
+        cy = params["intrinsic"]["v0"]
+        intrinsic = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
+        return intrinsic.astype(np.float32)
+
+    def get_stereo_extrinsic(self, index=0):
+        params = self._get_camera_param(index)
+        baseline = params["extrinsic"]["baseline"]
+        # pose to transform points in right frame to left frame
+        stereo_T_LR = np.array([[1, 0, 0, 0], [0, 1, 0, baseline], [0, 0, 1, 0], [0, 0, 0, 1]])
+        return stereo_T_LR.astype(np.float32)
+
+    """
+    Private methods used inside this class
+    """
+    def _get_camera_param(self, index):
+        if self.cur_camera_index == index:
+            return self.cur_camera_param
+
+        filename = self.frame_names[index].replace("leftImg8bit_sequence", "camera")
+        filename = filename.replace("leftImg8bit", "camera")
+        subdrive = filename.split("_")[:-2]
+        subdrive = "_".join(subdrive)
+        subdrive_files = [file for file in self.camera_names if file.startswith(subdrive)]
+        if not subdrive_files:
+            raise ValueError(f"No json file like {subdrive}")
+
+        filename = subdrive_files[0]
+        contents = self.zip_files["camera"].read(filename)
+        param = json.loads(contents)
+        self.cur_camera_param = param
+        self.cur_camera_index = index
+        return param
+
+
+def city_resize_depth_map(depth_map, srcshape_hw, dstshape_hw, intrinsic):
+    # depth_view = apply_color_map(depth_map)
+    # depth_view = cv2.resize(depth_view, (dstshape_hw[1], dstshape_hw[0]))
+    # cv2.imshow("srcdepth", depth_view)
+    du, dv = np.meshgrid(np.arange(dstshape_hw[1]), np.arange(dstshape_hw[0]))
+    du, dv = (du.reshape(-1), dv.reshape(-1))
+    scale_y, scale_x = (srcshape_hw[0] / dstshape_hw[0], srcshape_hw[1] / dstshape_hw[1])
+    su, sv = (du * scale_x).astype(np.uint16), (dv * scale_y).astype(np.uint16)
+    radi_x, radi_y = (int(scale_x/2), int(scale_y/2))
+    # print("su", su[0:800:40])
+    # print("sv", sv[0:-1:10000])
+
+    dst_depth = np.zeros(du.shape).astype(np.float32)
+    weight = np.zeros(du.shape).astype(np.float32)
+    for dy in range(-radi_y, radi_y+1):
+        for dx in range(-radi_x, radi_x+1):
+            v_inds = np.clip(sv + dy, 0, srcshape_hw[0] - 1).astype(np.uint16)
+            u_inds = np.clip(su + dx, 0, srcshape_hw[1] - 1).astype(np.uint16)
+
+            # if (dx==1) and (dy==1):
+            #     print("u_inds", u_inds[0:400:20])
+            #     print("v_inds", v_inds[0:-1:10000])
+            tmp_depth = depth_map[v_inds, u_inds]
+            tmp_weight = (tmp_depth > 0).astype(np.uint8)
+            dst_depth += tmp_depth
+            weight += tmp_weight
+
+    dst_depth[weight > 0] /= weight[weight > 0]
+    dst_depth = dst_depth.reshape((dstshape_hw[0], dstshape_hw[1], 1))
+    return dst_depth
+
+
+import cv2
+from config import opts
+import zipfile
+
+
+def test_city_reader():
+    srcpath = "/media/ian/IanBook/datasets/raw_zips/cityscapes/leftImg8bit_sequence_trainvaltest.zip"
+    zip_files = dict()
+    zip_files["leftimg"] = zipfile.ZipFile(srcpath, "r")
+    if srcpath.endswith("sequence_trainvaltest.zip"):
+        zip_files["camera"] = zipfile.ZipFile(srcpath.replace("/leftImg8bit_sequence_", "/camera_"), "r")
+    else:
+        zip_files["camera"] = zipfile.ZipFile(srcpath.replace("/leftImg8bit_", "/camera_"), "r")
+    zip_files["disparity"] = zipfile.ZipFile(srcpath.replace("/leftImg8bit_", "/disparity_"), "r")
+    drive_paths = list_drive_paths(zip_files["leftimg"].namelist())
+
+    for drive_path in drive_paths:
+        print("\n!!! New drive start !!!", drive_path)
+        reader = CityReader("train", zip_files)
+        reader.init_drive(drive_path)
+        frame_indices = reader.get_range_()
+        for fi in frame_indices:
+            image = reader.get_image(fi)
+            intrinsic = reader.get_intrinsic(fi)
+            depth = reader.get_depth(fi, image.shape[:2], opts.get_shape("HW", "cityscapes"), intrinsic)
+            print(f"== test_city_reader) drive: {op.basename(drive_path)}, frame: {fi}")
+            view = image[0:-1:5, 0:-1:5, :]
+            depth_view = apply_color_map(depth)
+            cv2.imshow("image", view)
+            cv2.imshow("dstdepth", depth_view)
+            key = cv2.waitKey(2000)
+            if key == ord('q'):
+                break
+
+
+def list_drive_paths(filelist):
+    filelist = [file for file in filelist if file.endswith(".png")]
+    filelist.sort()
+    # drive path example: /leftImg8bit_sequence/train/aachen/aachen
+    drive_paths = ["_".join(file.split("_")[:-3]) for file in filelist]
+    drive_paths = list(set(drive_paths))
+    drive_paths.sort()
+    return drive_paths
+
+
+def apply_color_map(depth):
+    depth_view = (np.clip(depth, 0, 50.) / 50. * 256).astype(np.uint8)
+    depth_view = cv2.applyColorMap(depth_view, cv2.COLORMAP_SUMMER)
+    return depth_view
+
+
+if __name__ == "__main__":
+    test_city_reader()
+

--- a/tfrecords/readers/reader_base.py
+++ b/tfrecords/readers/reader_base.py
@@ -55,7 +55,7 @@ class DataReaderBase:
         """
         raise NotImplementedError()
 
-    def get_stereo_extrinsic(self):
+    def get_stereo_extrinsic(self, index=0):
         """
         :return: stereo extrinsic pose that transforms point in right frame into left frame
         """

--- a/tfrecords/readers/test_zipfile.py
+++ b/tfrecords/readers/test_zipfile.py
@@ -1,0 +1,139 @@
+import zipfile
+import tarfile
+from PIL import Image
+import cv2
+import numpy as np
+import json
+from glob import glob
+from utils.util_funcs import print_progress_status
+from matplotlib import pyplot as plt
+
+
+def count_images_from_zip(zip_pattern, image_suffix):
+    print("==== zip pattern:", zip_pattern)
+    zip_files = glob(zip_pattern)
+    frame_counts = []
+    for zip_name in zip_files:
+        print("== zip file:", zip_name)
+        zfile = zipfile.ZipFile(zip_name)
+        filelist = zfile.namelist()
+        filelist = [file for file in filelist if file.endswith(image_suffix)]
+        filelist.sort()
+        if len(filelist) < 100:
+            continue
+
+        frame_counts.append(len(filelist))
+        print("image file list:", len(filelist))
+        for i in range(0, len(filelist), len(filelist)//5):
+            print(i, filelist[i])
+
+        image_bytes = zfile.open(filelist[0])
+        image = Image.open(image_bytes)
+        image = np.array(image, np.uint8)
+        print("image:", image.shape, image.dtype, np.max(image), np.min(image), np.median(image))
+        cv2.imshow("image", image)
+        image[image > 10000] = 2 ** 16 - 1
+        cv2.imshow("depth", image)
+        cv2.waitKey(0)
+
+    frame_counts = np.array(frame_counts)
+    total_frames = np.sum(frame_counts)
+    print("frame_counts:", frame_counts)
+    print("total_frames:", total_frames)
+    print("\n\n")
+
+
+def show_depth_from_zip(zip_pattern, image_suffix):
+    print("==== zip pattern:", zip_pattern)
+    zip_files = glob(zip_pattern)
+    for zip_name in zip_files:
+        print("== zip file:", zip_name)
+        zfile = zipfile.ZipFile(zip_name)
+        filelist = zfile.namelist()
+        filelist = [file for file in filelist if file.endswith(image_suffix)]
+        filelist.sort()
+        if len(filelist) < 100:
+            continue
+
+        print("disparity files:", len(filelist))
+        for i in range(0, len(filelist), len(filelist)//5):
+            print(i, filelist[i])
+            disp_bytes = zfile.open(filelist[i])
+            disp = Image.open(disp_bytes)
+            disp = np.array(disp, np.uint16).astype(np.float32)
+            disp[disp > 0] = (disp[disp > 0] - 1) / 256.
+            depth = np.copy(disp)
+            # depth = baseline * focal length / disparity
+            depth[disp > 0] = (0.209313 * 2262.52) / disp[disp > 0]
+            depth[depth > 50] = 50
+            print("depth:", i, np.min(depth[depth > 0]), np.max(depth[depth > 0]), np.median(depth[depth > 0]))
+            depth_view = (depth / 50. * 256).astype(np.uint8)
+            depth_view = cv2.applyColorMap(depth_view, cv2.COLORMAP_SUMMER)
+            cv2.imshow("depth", depth_view)
+            cv2.waitKey(0)
+
+
+def open_text_from_zip():
+    zfile = zipfile.ZipFile("/media/ian/IanBook/datasets/raw_zips/cityscapes/camera_trainextra.zip")
+    filelist = zfile.namelist()
+    filelist = [file for file in filelist if file.endswith(".json")]
+    filelist.sort()
+    print("text file list:", len(filelist))
+    for i in range(0, len(filelist), 1000):
+        print(i, filelist[i])
+
+    contents = zfile.read(filelist[0])
+    print("text contents", contents)
+    params = json.loads(contents)
+    print("params", type(params), params)
+
+
+def convert_tar_to_vanilla_zip():
+    print("\n==== convert_tar_to_vanilla_zip")
+    tar_pattern = "/media/ian/IanBook/datasets/raw_zips/nuscenes/v1.0-trainval*.tar"
+
+    tar_files = glob(tar_pattern)
+    for ti, tar_name in enumerate(tar_files):
+        if ti > 2:
+            break
+        print("==== tar file:", tar_name)
+        tfile = tarfile.open(tar_name, 'r')
+        zip_name = tar_name.replace(".tar", ".zip")
+        zip_name = zip_name.replace("/nuscenes/", "/nuscenes_zip/")
+        print("==== zip file:", zip_name)
+        zfile = zipfile.ZipFile(zip_name, 'w', compression=zipfile.ZIP_STORED)
+
+        for fi, intar_file in enumerate(tfile):
+            if not intar_file.isfile():
+                continue
+            inzip_name = intar_file.name
+            if "sweeps/CAM_FRONT/n" not in inzip_name:
+                print_progress_status(f"== converting: (NOT FRONT) {ti} tar, {fi} file in tar, {inzip_name[:40]}")
+                continue
+
+            contents = tfile.extractfile(intar_file)
+            contents = contents.read()
+            zfile.writestr(inzip_name, contents)
+            print_progress_status(f"== converting: (CAM_FRONT) {ti}-th tar, {fi}-th file in tar, {inzip_name[:40]}")
+
+        print("\n==== close tar and zip")
+        tfile.close()
+        zfile.close()
+
+
+if __name__ == "__main__":
+    # zip_pattern = "/media/ian/IanBook/datasets/raw_zips/cityscapes/leftImg8bit_*.zip"
+    # count_images_from_zip(zip_pattern, ".png")
+
+    zip_pattern = "/media/ian/IanBook/datasets/raw_zips/cityscapes/disparity_*.zip"
+    show_depth_from_zip(zip_pattern, ".png")
+
+    # zip_pattern = "/media/ian/IanBook/datasets/raw_zips/driving_stereo/train-left-image/*.zip"
+    # count_images_from_zip(zip_pattern, ".jpg")
+
+    # open_text_from_zip()
+
+    # convert_tar_to_vanilla_zip()
+    # zip_pattern = "/media/ian/IanBook/datasets/raw_zips/nuscenes_zip/*.zip"
+    # count_images_from_zip(zip_pattern, ".jpg")
+

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -66,7 +66,7 @@ class WaymoReader(DataReaderBase):
         intrin = np.array([[intrin[0], 0, intrin[2]], [0, intrin[1], intrin[3]], [0, 0, 1]])
         return intrin.astype(np.float32)
 
-    def get_stereo_extrinsic(self):
+    def get_stereo_extrinsic(self, index=0):
         return None
 
     def get_filename(self, example_index):

--- a/tfrecords/tfr_util.py
+++ b/tfrecords/tfr_util.py
@@ -59,14 +59,14 @@ def read_data_config(value):
         elif value.dtype == np.float32:
             decode_type = "tf.float32"
         else:
-            assert 0, f"[FeederBase] Wrong numpy type: {value.dtype}"
+            assert 0, f"[read_data_config] Wrong numpy type: {value.dtype}"
         parse_type = "tf.string"
         shape = list(value.shape)
     elif isinstance(value, int):
         parse_type = "tf.int64"
         shape = None
     else:
-        assert 0, f"[FeederBase] Wrong type: {type(value)}"
+        assert 0, f"[read_data_config] Wrong type: {type(value)}"
 
     return {"parse_type": parse_type, "decode_type": decode_type, "shape": shape}
 

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -25,7 +25,7 @@ class TfrecordMakerBase:
         self.example_count_in_shard = 0     # number of examples in this shard
         self.example_count_in_drive = 0     # number of examples in this drive
         self.drive_paths = self.list_drive_paths(srcpath, split)
-        self.data_keys = self.get_dataset_keys(dataset, split, stereo)
+        self.data_keys = self.get_dataset_keys(dataset.split("__")[0], split, stereo)
         self.example_maker = self.get_example_maker(dataset, split, shwc_shape, self.data_keys)
         self.serialize_example = Serializer()
         self.writer = None
@@ -36,27 +36,27 @@ class TfrecordMakerBase:
 
     def get_dataset_keys(self, dataset, split, stereo):
         keys = []
-        if dataset is "kitti_raw":
+        if dataset == "kitti_raw":
             keys = ["image", "intrinsic", "depth_gt", "pose_gt"]
             if stereo:
                 keys += ["image_R", "intrinsic_R", "depth_gt_R", "pose_gt_R", "stereo_T_LR"]
-        elif dataset is "kitti_odom":
+        elif dataset == "kitti_odom":
             keys = ["image", "intrinsic", "pose_gt"] if split is "test" else ["image", "intrinsic"]
             if stereo:
                 if split is "test":
                     keys += ["image_R", "intrinsic_R", "pose_gt_R", "stereo_T_LR"]
                 else:
                     keys += ["image_R", "intrinsic_R", "stereo_T_LR"]
-        elif dataset is "cityscapes":
-            keys = ["image", "intrinsic", "depth_gt", "pose_gt"]
-        elif dataset is "waymo":
+        elif dataset == "cityscapes":
+            keys = ["image", "intrinsic", "depth_gt", "stereo_T_LR"]
+        elif dataset == "waymo":
             keys = ["image", "intrinsic", "depth_gt", "pose_gt"]
         else:
             assert 0, f"[get_dataset_keys] Wrong dataset: {dataset}, {split}, {stereo}"
         return keys
 
-    def get_example_maker(self, *args):
-        return ExampleMaker(*args)
+    def get_example_maker(self, dataset, split, shwc_shape, data_keys):
+        return ExampleMaker(dataset, split, shwc_shape, data_keys)
 
     def make(self, max_frames=0):
         num_drives = len(self.drive_paths)
@@ -70,8 +70,8 @@ class TfrecordMakerBase:
 
                 # create data reader in example maker
                 self.example_maker.init_reader(drive_path)
-                num_frames = self.example_maker.num_frames()
                 loop_range = self.example_maker.get_range()
+                num_frames = self.example_maker.num_frames()
 
                 last_example = dict()
                 for index in loop_range:
@@ -153,6 +153,92 @@ class WaymoTfrecordMaker(TfrecordMakerBase):
 
     def open_new_writer(self, drive_index):
         outfile = f"{self.tfr_drive_path}/drive_{drive_index:03d}_shard_{self.shard_count:03d}.tfrecord"
+        self.writer = tf.io.TFRecordWriter(outfile)
+
+    def write_tfrecord_config(self, example):
+        config = inspect_properties(example)
+        config["length"] = self.example_count_in_drive
+        config["imshape"] = self.shwc_shape
+        print("## save config", config)
+        with open(op.join(self.tfr_drive_path, "tfr_config.txt"), "w") as fr:
+            json.dump(config, fr)
+
+    def wrap_up(self):
+        files = glob(f"{self.tfrpath__}/*/*.tfrecord")
+        print("[wrap_up] move tfrecords:", files[0:-1:5])
+        for file in files:
+            shutil.move(file, op.join(self.tfrpath__, op.basename(file)))
+
+        # merge config files of all drives and save only one in tfrpath
+        files = glob(f"{self.tfrpath__}/*/tfr_config.txt")
+        print("[wrap_up] config files:", files[:5])
+        total_length = 0
+        config = dict()
+        for file in files:
+            with open(file, 'r') as fp:
+                config = json.load(fp)
+                total_length += config["length"]
+        config["length"] = total_length
+        with open(op.join(self.tfrpath__, "tfr_config.txt"), "w") as fr:
+            json.dump(config, fr)
+
+        os.rename(self.tfrpath__, self.tfrpath)
+
+
+import zipfile
+
+
+class CityscapesTfrecordMaker(TfrecordMakerBase):
+    def __init__(self, dataset, split, srcpath, tfrpath, shard_size, stereo, shwc_shape):
+        self.zip_suffix = "extra" if srcpath.endswith("trainextra.zip") else "sequence"
+        self.zip_suffix = "sequence" if srcpath.endswith("sequence_trainvaltest.zip") else self.zip_suffix
+        print("self.zip_suffix", self.zip_suffix)
+        self.zip_files = self.open_zip_files(srcpath)
+        super().__init__(dataset, split, srcpath, tfrpath, shard_size, stereo, shwc_shape)
+
+    def open_zip_files(self, srcpath):
+        zip_files = dict()
+        zip_files["leftimg"] = zipfile.ZipFile(srcpath, "r")
+        if srcpath.endswith("sequence_trainvaltest.zip"):
+            zip_files["camera"] = zipfile.ZipFile(srcpath.replace("/leftImg8bit_sequence_", "/camera_"), "r")
+        else:
+            zip_files["camera"] = zipfile.ZipFile(srcpath.replace("/leftImg8bit_", "/camera_"), "r")
+        zip_files["disparity"] = zipfile.ZipFile(srcpath.replace("/leftImg8bit_", "/disparity_"), "r")
+        return zip_files
+
+    def get_example_maker(self, dataset, split, shwc_shape, data_keys):
+        return ExampleMaker(dataset, split, shwc_shape, data_keys, self.zip_files)
+
+    def list_drive_paths(self, srcpath, split):
+        filelist = self.zip_files["leftimg"].namelist()
+        filelist = [file for file in filelist if file.endswith(".png")]
+        filelist.sort()
+        # drive path example: /leftImg8bit_sequence/train/aachen/aachen
+        drive_paths = ["_".join(file.split("_")[:-3]) for file in filelist]
+        drive_paths = list(set(drive_paths))
+        drive_paths.sort()
+        return drive_paths
+
+    def init_tfrecord(self, drive_index=0):
+        city = self.drive_paths[drive_index].split("/")[-1]
+        # example: cityscapes__/sequence_aachen
+        outpath = op.join(self.tfrpath__, f"{self.zip_suffix}_{city}")
+        print("outpath", outpath)
+        if op.isdir(outpath):
+            print(f"[init_tfrecord] {op.basename(outpath)} exists. move onto the next")
+            return True
+
+        # change path to check date integrity
+        self.pm.reopen([outpath], closer_func=self.on_exit)
+        self.tfr_drive_path = outpath
+        self.shard_count = 0
+        self.example_count_in_shard = 0
+        self.example_count_in_drive = 0
+        self.open_new_writer(drive_index)
+        return False
+
+    def open_new_writer(self, drive_index):
+        outfile = f"{self.tfr_drive_path}/{self.zip_suffix}_shard_{self.shard_count:03d}.tfrecord"
         self.writer = tf.io.TFRecordWriter(outfile)
 
     def write_tfrecord_config(self, example):


### PR DESCRIPTION
cityscapes 데이터셋을 압축을 풀지 않고 zip에서 바로 데이터를 읽어서 tfrecord로 변환

## test_zipfile.py

zipfile을 활용법을 시험해보는 스크립트

- count_images_from_zip(): zip 파일 안의 이미지 파일 개수 세어줌
- show_depth_from_zip(): zip 파일 안의 depth 데이터 읽어서 시각화
- open_text_from_zip(): zip 파일에서 텍스트 데이터 읽어서 보여줌

## CityscapesTfrecordMaker

- cityscapes 데이터셋에서 drive 목록을 만들기
- snippet 단위로 모아서 example을 만들기
- drive 마다 tfrecord를 shard 단위로 끊어서 만들기

## CityReader

- tfrecords.readers.reader_base.py의 DataReaderBase를 상속받은 CityReader 클래스 구현
- Cityscapes 데이터를 zip 파일로부터 읽을 수 있도록 zipfile 패키지 활용
- test_city_reader(): CityReader에서 데이터 읽는 기능을 확인하는 함수
- test_city_stereo_synthesis(): 만들어진 tfrecord로부터 stereo synthesis가 잘 되는지 확인하는 함수

