### PR TITLE
Create validation tfrecords

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -30,7 +30,7 @@ class VodeOptions:
     MIN_DEPTH = 1e-3
     MAX_DEPTH = 80
     VALIDATION_FRAMES = 500
-    DATASETS_TO_PREPARE = {"kitti_raw": ["test", "test"],
+    DATASETS_TO_PREPARE = {"kitti_raw": ["train", "test"],
                            "kitti_odom": ["train", "test"],
                            "cityscapes__extra": ["train"],
                            "cityscapes__sequence": ["train"],
@@ -38,8 +38,8 @@ class VodeOptions:
                            "driving_stereo": ["train", "test"],
                            }
     # only when making small tfrecords to test training
-    DRIVE_LIMIT = 0
-    FRAME_LIMIT = 0
+    DRIVE_LIMIT = 3
+    FRAME_LIMIT = 100
     AUGMENT_PROBS = {"CropAndResize": 0.2,
                      "HorizontalFlip": 0.2,
                      "ColorJitter": 0.2}
@@ -50,7 +50,7 @@ class VodeOptions:
     DATAPATH = RESULT_DATAPATH
     assert(op.isdir(DATAPATH))
     DATAPATH_SRC = op.join(DATAPATH, "srcdata")
-    DATAPATH_TFR = op.join(DATAPATH, "tfrecords")
+    DATAPATH_TFR = op.join(DATAPATH, "tfrecords_small")
     DATAPATH_CKP = op.join(DATAPATH, "checkpts")
     DATAPATH_LOG = op.join(DATAPATH, "log")
     DATAPATH_PRD = op.join(DATAPATH, "prediction")

--- a/evaluate/evaluate_debug.py
+++ b/evaluate/evaluate_debug.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 
 import settings
 from config import opts
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 import utils.util_funcs as uf
 import utils.convert_pose as cp
 import evaluate.eval_funcs as ef
@@ -39,7 +39,7 @@ def evaluate_for_debug(data_dir_name, model_name):
     model = try_load_weights(model, model_name)
     model.compile(optimizer="sgd", loss="mean_absolute_error")
 
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1).get_dataset()
     depth_result = []
     pose_result = []
     trajectory = []

--- a/evaluate/evaluate_main.py
+++ b/evaluate/evaluate_main.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import settings
 from config import opts
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 import utils.util_funcs as uf
 import evaluate.eval_funcs as ef
 
@@ -42,7 +42,7 @@ def evaluate_by_user_interaction():
 
 def evaluate(data_dir_name, model_name):
     total_depth_pred, total_pose_pred = load_predictions(model_name)
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1).get_dataset()
     depth_valid = uf.check_tfrecord_including(op.join(opts.DATAPATH_TFR, data_dir_name), ["depth_gt"])
     if not uf.check_tfrecord_including(op.join(opts.DATAPATH_TFR, data_dir_name), ["pose_gt"]):
         print("Evaluation is NOT possible without pose_gt")

--- a/evaluate/visualize_main.py
+++ b/evaluate/visualize_main.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 
 import settings
 from config import opts
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 import utils.util_funcs as uf
 
 
@@ -47,8 +47,8 @@ def visualize(data_dir_name, model_name):
     depths = np.load(op.join(opts.DATAPATH_PRD, model_name, "depth.npy"))
     poses = np.load(op.join(opts.DATAPATH_PRD, model_name, "pose.npy"))
     print(f"depth shape: {depths.shape}, pose shape: {poses.shape}")
-    tfrgen = TfrecordGenerator(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1)
-    dataset = tfrgen.get_generator()
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1)
+    dataset = tfrgen.get_dataset()
     fig = plt.figure()
     fig.subplots_adjust(top=0.99, bottom=0.01, left=0.2, right=0.99)
 

--- a/model/build_model/model_factory.py
+++ b/model/build_model/model_factory.py
@@ -139,7 +139,7 @@ class ExponentialActivation:
 # ==================================================
 import os.path as op
 from config import opts
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 
 
 def test_build_model():
@@ -162,8 +162,8 @@ def test_build_model():
 
 def test_model_predictions():
     print("\n===== start test_model_predictions")
-    tfrgen = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=False)
-    dataset = tfrgen.get_generator()
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=False)
+    dataset = tfrgen.get_dataset()
     total_steps = tfrgen.get_total_steps()
     vode_model = ModelFactory(stereo=True).get_model()
 

--- a/model/loss_and_metric/test_loss.py
+++ b/model/loss_and_metric/test_loss.py
@@ -8,7 +8,7 @@ import settings
 from config import opts
 import utils.util_funcs as uf
 import utils.convert_pose as cp
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 from model.synthesize.synthesize_base import SynthesizeMultiScale
 import model.loss_and_metric.losses as ls
 
@@ -22,7 +22,7 @@ def test_photometric_loss_quality(suffix=""):
     assert 없음
     """
     print("\n===== start test_photometric_loss_quality")
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_dataset()
 
     for i, features in enumerate(dataset):
         print("\n--- fetch a batch data")
@@ -83,7 +83,7 @@ def test_photometric_loss_quantity(suffix=""):
     두 가지 pose로 복원된 영상을 눈으로 확인하고 gt 데이터의 loss가 더 낮음을 확인 (assert)
     """
     print("\n===== start test_photometric_loss_quantity")
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_dataset()
 
     for i, features in enumerate(dataset):
         print("\n--- fetch a batch data")
@@ -155,7 +155,7 @@ def test_smootheness_loss_quantity():
     두 가지 depth를 눈으로 확인하고 gt 데이터의 loss가 더 낮음을 확인 (assert)
     """
     print("\n===== start test_smootheness_loss_quantity")
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_dataset()
 
     """
     gather additional data required to compute losses
@@ -231,7 +231,7 @@ def tu_smootheness_loss(depth_gt, target_image):
 
 def test_stereo_loss():
     print("\n===== start test_photometric_loss_quality")
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_dataset()
     stereo_loss = ls.StereoDepthLoss("L1")
     total_loss = ls.TotalLoss()
 

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import settings
 from config import opts
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 import utils.util_funcs as uf
 from model.build_model.model_factory import ModelFactory
 from model.model_util.augmentation import augmentation_factory
@@ -90,7 +90,7 @@ def get_dataset(dataset_name, split, shuffle):
     batch_size = opts.BATCH_SIZE
     tfr_train_path = op.join(opts.DATAPATH_TFR, f"{dataset_name}_{split}")
     assert op.isdir(tfr_train_path)
-    dataset = TfrecordGenerator(tfr_train_path, shuffle=shuffle, batch_size=batch_size).get_generator()
+    dataset = TfrecordReader(tfr_train_path, shuffle=shuffle, batch_size=batch_size).get_dataset()
     steps_per_epoch = uf.count_steps(tfr_train_path, batch_size)
     return dataset, steps_per_epoch
 
@@ -151,7 +151,7 @@ def test_model_wrapper_output():
     model = ModelFactory().get_model()
     model = try_load_weights(model, ckpt_name)
     model.compile(optimizer="sgd", loss="mean_absolute_error")
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, test_dir_name)).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, test_dir_name)).get_dataset()
 
     print("===== check model output shape")
     for features in dataset:

--- a/model/model_util/augmentation.py
+++ b/model/model_util/augmentation.py
@@ -332,7 +332,7 @@ def test_flip_intrinsic():
 import os.path as op
 import cv2
 from config import opts
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 from utils.util_funcs import to_uint8_image, multi_scale_depths
 from model.synthesize.synthesize_base import SynthesizeMultiScale
 from utils.convert_pose import pose_matr2rvec_batch
@@ -340,8 +340,8 @@ from utils.convert_pose import pose_matr2rvec_batch
 
 def test_augmentations():
     print("===== test test_augmentations")
-    tfrgen = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=False)
-    dataset = tfrgen.get_generator()
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=False)
+    dataset = tfrgen.get_dataset()
     total_aug = TotalAugment()
     data_aug = {"CropAndResize": CropAndResize(aug_prob=0.5),
                 "HorizontalFlip": HorizontalFlip(aug_prob=0.5),
@@ -418,8 +418,8 @@ def prep_synthesize(features):
 
 def test_augmentation_factory():
     print("===== test test_augmentations")
-    tfrgen = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=False)
-    dataset = tfrgen.get_generator()
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=False)
+    dataset = tfrgen.get_dataset()
     augmenter = augmentation_factory(opts.AUGMENT_PROBS)
 
     for bi, features in enumerate(dataset):
@@ -456,8 +456,8 @@ import utils.util_funcs as uf
 
 def test_stereo_augmentation():
     print("===== test test_augmentations")
-    tfrgen = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=False)
-    dataset = tfrgen.get_generator()
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=False)
+    dataset = tfrgen.get_dataset()
     augmenter = augmentation_factory(opts.AUGMENT_PROBS)
     batidx, sclidx = 0, 0
 

--- a/model/synthesize/test_synthesizing.py
+++ b/model/synthesize/test_synthesizing.py
@@ -7,7 +7,7 @@ import cv2
 from config import opts
 from model.synthesize.synthesize_base import SynthesizeSingleScale, SynthesizeMultiScale
 from model.synthesize.bilinear_interp import BilinearInterpolation
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 from model.model_util.augmentation import augmentation_factory
 import utils.convert_pose as cp
 import utils.util_funcs as uf
@@ -22,7 +22,7 @@ def test_synthesize_batch_multi_scale():
     """
     print("===== start test_synthesize_batch_multi_scale")
     dataname, split = "waymo", "train"
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, f"{dataname}_{split}")).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, f"{dataname}_{split}")).get_dataset()
     augmenter = augmentation_factory(opts.AUGMENT_PROBS)
 
     for i, features in enumerate(dataset):
@@ -64,7 +64,7 @@ def test_synthesize_batch_view():
     gt depth와 gt pose를 입력했을 때 스케일 별로 복원되는 이미지를 정성적으로 확인
     실제 target image와 복원된 "single" scale target image를 눈으로 비교
     """
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_dataset()
 
     print("\n===== start test_synthesize_batch_view")
     scale_idx = 1
@@ -116,7 +116,7 @@ def test_reshape_source_images():
     위 아래로 쌓인 원본 이미지를 batch 아래 한 차원을 더 만들어서 reshape이 잘 됐는지 확인(assert)
     """
     print("===== start test_reshape_source_images")
-    dataset = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_generator()
+    dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test")).get_dataset()
     dataset = iter(dataset)
     features = next(dataset)
     stacked_image = features['image']

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -1,30 +1,10 @@
-import os
 import os.path as op
-from glob import glob
 import numpy as np
 
 import settings
 from config import opts
 from utils.util_class import WrongInputException
-from utils.util_class import PathManager
-from tfrecords.tfrecord_writer import TfrecordMaker
 import tfrecords.tfrecord_maker as tm
-
-
-def convert_to_tfrecords():
-    src_paths = glob(op.join(opts.DATAPATH_SRC, "*"))
-    src_paths = [path for path in src_paths if op.isdir(path)]
-    print("[convert_to_tfrecords] top paths:", src_paths)
-    for srcpath in src_paths:
-        tfrpath = op.join(opts.DATAPATH_TFR, op.basename(srcpath))
-        if op.isdir(tfrpath):
-            print("[convert_to_tfrecords] tfrecord already created in", tfrpath)
-        else:
-            with PathManager([tfrpath]) as pm:
-                tfrmaker = TfrecordMaker(srcpath, tfrpath, opts.STEREO, opts.get_shape("SHWC"))
-                tfrmaker.make()
-                # if set_ok() was NOT excuted, the generated path is removed
-                pm.set_ok()
 
 
 def convert_to_tfrecords_directly():

--- a/tfrecords/readers/city_reader.py
+++ b/tfrecords/readers/city_reader.py
@@ -168,7 +168,7 @@ def list_drive_paths(filelist):
     return drive_paths
 
 
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 from model.synthesize.synthesize_base import SynthesizeMultiScale
 import utils.util_funcs as uf
 import utils.convert_pose as cp
@@ -177,7 +177,7 @@ import tensorflow as tf
 
 def test_city_stereo_synthesis():
     tfrpath = op.join(opts.DATAPATH_TFR, "cityscapes_train__")
-    dataset = TfrecordGenerator(tfrpath).get_generator()
+    dataset = TfrecordReader(tfrpath).get_dataset()
     batid, srcid = 0, 0
 
     for i, features in enumerate(dataset):

--- a/tfrecords/readers/driving_reader.py
+++ b/tfrecords/readers/driving_reader.py
@@ -130,7 +130,7 @@ def test_driving_stereo_reader():
                 break
 
 
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 from model.synthesize.synthesize_base import SynthesizeMultiScale
 import utils.util_funcs as uf
 import utils.convert_pose as cp
@@ -139,7 +139,7 @@ import tensorflow as tf
 
 def test_driving_stereo_synthesis():
     tfrpath = op.join(opts.DATAPATH_TFR, "driving_stereo_train")
-    dataset = TfrecordGenerator(tfrpath).get_generator()
+    dataset = TfrecordReader(tfrpath).get_dataset()
     batid, srcid = 0, 0
 
     for i, features in enumerate(dataset):

--- a/tfrecords/readers/kitti_reader.py
+++ b/tfrecords/readers/kitti_reader.py
@@ -121,7 +121,7 @@ class KittiRawReader(DataReaderBase):
 
     def _read_frame_ids_test(self, drive_key):
         date, drive_id = drive_key
-        drive_prefix = f"{date}_{drive_id}"
+        drive_prefix = f"{date} {drive_id}"
         prj_tfrecords_path = op.dirname(op.dirname(op.abspath(__file__)))
         filename = op.join(prj_tfrecords_path, "resources", "kitti_test_depth_frames.txt")
         with open(filename, "r") as fr:

--- a/tfrecords/readers/kitti_reader.py
+++ b/tfrecords/readers/kitti_reader.py
@@ -396,7 +396,7 @@ def test_kitti_odom_reader():
                 break
 
 
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 from model.synthesize.synthesize_base import SynthesizeMultiScale
 import utils.util_funcs as uf
 import utils.convert_pose as cp
@@ -405,7 +405,7 @@ import tensorflow as tf
 
 def test_kitti_raw_synthesis():
     tfrpath = op.join(opts.DATAPATH_TFR, "kitti_raw_train")
-    dataset = TfrecordGenerator(tfrpath).get_generator()
+    dataset = TfrecordReader(tfrpath).get_dataset()
     batid, srcid = 0, 0
 
     for i, features in enumerate(dataset):

--- a/tfrecords/test_reader.py
+++ b/tfrecords/test_reader.py
@@ -7,17 +7,17 @@ from tensorflow.keras.layers import Conv2D, MaxPooling2D, GlobalAvgPool2D
 
 import settings
 from config import opts
-from tfrecords.tfrecord_reader import TfrecordGenerator
+from tfrecords.tfrecord_reader import TfrecordReader
 import gc
 
 
 def test_tfrecord_reader():
     """
-    Test if TfrecordGenerator works fine and print keys and shapes of input tensors
+    Test if TfrecordReader works fine and print keys and shapes of input tensors
     """
     model = create_model()
-    tfrgen = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=True)
-    dataset = tfrgen.get_generator()
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_test"), shuffle=True)
+    dataset = tfrgen.get_dataset()
     batch_means = []
     for ei in range(50):
         y_means = []

--- a/tfrecords/tfr_util.py
+++ b/tfrecords/tfr_util.py
@@ -1,6 +1,7 @@
 import numpy as np
 import cv2
 import tensorflow as tf
+from utils.convert_pose import pose_matr2rvec
 
 
 class Serializer:
@@ -109,4 +110,30 @@ def apply_color_map(depth):
     depth_view = (np.clip(depth, 0, 50.) / 50. * 255).astype(np.uint8)
     depth_view = cv2.applyColorMap(depth_view, cv2.COLORMAP_SUMMER)
     return depth_view
+
+
+def show_example(example, wait=0, print_param=False):
+    image = example["image"]
+    dstshape = (int(image.shape[1] * 1000. / image.shape[0]), 1000)
+    image_view = cv2.resize(image, dstshape) if image.shape[0] > 1000 else image.copy()
+    cv2.imshow("image", image_view)
+
+    if "image_R" in example:
+        image = example["image_R"]
+        image_view = cv2.resize(image, dstshape) if image.shape[0] > 1000 else image.copy()
+        cv2.imshow("image_R", image_view)
+
+    if "depth_gt" in example:
+        depth = example["depth_gt"]
+        depth_view = (np.clip(depth, 0, 50.) / 50. * 256).astype(np.uint8)
+        depth_view = cv2.applyColorMap(depth_view, cv2.COLORMAP_SUMMER)
+        cv2.imshow("depth", depth_view)
+
+    if print_param:
+        print("\nintrinsic:\n", example["intrinsic"])
+        if "pose_gt" in example:
+            print("pose\n", pose_matr2rvec(example["pose_gt"]))
+
+    cv2.waitKey(wait)
+
 

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -18,7 +18,7 @@ class TfrecordMakerBase:
         self.srcpath = srcpath
         self.tfrpath = tfrpath              # final root path of tfrecords of this dataset
         self.tfrpath__ = tfrpath + "__"     # temporary root path of tfrecords of this dataset
-        self.tfr_drive_path = tfrpath       # path to write "current" tfrecords
+        self.tfr_drive_path = ""            # path to write "current" tfrecords
         self.shwc_shape = shwc_shape
         self.shard_size = shard_size        # max number of examples in a shard
         self.shard_count = 0                # number of shards written in this drive
@@ -163,11 +163,13 @@ class TfrecordMakerSingleDir(TfrecordMakerBase):
         self.pm.reopen([outpath], closer_func=self.on_exit)
         self.tfr_drive_path = outpath
         self.example_count_in_drive = 0
-        self.open_new_writer(drive_index)
+        if drive_index == 0:
+            self.open_new_writer(drive_index)
         return False
 
     def open_new_writer(self, drive_index):
         outfile = f"{self.tfr_drive_path}/shard_{self.shard_count:03d}.tfrecord"
+        print("open a new tfrecord:", op.basename(outfile))
         self.writer = tf.io.TFRecordWriter(outfile)
 
     def write_tfrecord_config(self, example):

--- a/tfrecords/tfrecord_reader.py
+++ b/tfrecords/tfrecord_reader.py
@@ -8,7 +8,7 @@ from config import opts
 import utils.util_funcs as uf
 
 
-class TfrecordGenerator:
+class TfrecordReader:
     def __init__(self, tfrpath, shuffle=False, epochs=1, batch_size=opts.BATCH_SIZE):
         self.tfrpath = tfrpath
         self.shuffle = shuffle
@@ -58,7 +58,7 @@ class TfrecordGenerator:
                                                        default_value=default_value)
         return features_dict
 
-    def get_generator(self):
+    def get_dataset(self):
         """
         :return features: {"image": .., "pose_gt": .., "depth_gt": .., "intrinsic": ..}
             image: image stacked in height [batch, snippet*height, width, 3]
@@ -113,10 +113,10 @@ class TfrecordGenerator:
 
 def test_read_dataset():
     """
-    Test if TfrecordGenerator works fine and print keys and shapes of input tensors
+    Test if TfrecordReader works fine and print keys and shapes of input tensors
     """
-    tfrgen = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_val"))
-    dataset = tfrgen.get_generator()
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_val"))
+    dataset = tfrgen.get_dataset()
     for i, x in enumerate(dataset):
         if i == 100:
             break
@@ -138,11 +138,11 @@ import numpy as np
 
 def test_reuse_dataset():
     """
-    Test if generator from TfrecordGenerator can be reused after a full iteration
+    Test if generator from TfrecordReader can be reused after a full iteration
     """
     np.set_printoptions(precision=3, suppress=True)
-    tfrgen = TfrecordGenerator(op.join(opts.DATAPATH_TFR, "kitti_raw_val"), epochs=2, batch_size=64)
-    dataset = tfrgen.get_generator()
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_val"), epochs=2, batch_size=64)
+    dataset = tfrgen.get_dataset()
     for i in range(2):
         print("Iteration:", i)
         for k, x in enumerate(dataset):

--- a/tfrecords/validation_maker.py
+++ b/tfrecords/validation_maker.py
@@ -1,0 +1,92 @@
+import os.path as op
+from config import opts
+import tensorflow as tf
+import json
+
+import utils.util_funcs as uf
+from utils.util_class import PathManager
+from tfrecords.tfrecord_reader import TfrecordReader
+from tfrecords.tfr_util import Serializer, show_example
+
+
+def generate_validation_tfrecords(tfrpath):
+    srcpath = check_source_path(tfrpath)
+    if srcpath is None:
+        return
+
+    dataset = TfrecordReader(srcpath, shuffle=True, batch_size=1).get_dataset()
+    with open(op.join(srcpath, "tfr_config.txt"), "r") as fr:
+        config = json.load(fr)
+    length = config["length"]
+    serialize_example = Serializer()
+    val_frames = opts.VALIDATION_FRAMES
+    stride = max(min(length // val_frames, 10), 1)
+    save_count = 0
+    print("\n\n!!! Start create", op.basename(tfrpath))
+    print(f"source length={length}, stride={stride}, val_frames={val_frames}")
+
+    with PathManager([tfrpath]) as pm:
+        outfile = f"{tfrpath}/validation.tfrecord"
+        with tf.io.TFRecordWriter(outfile) as tfrwriter:
+            for i, features in enumerate(dataset):
+                if i % stride != 0:
+                    continue
+
+                example = convert_to_np(features)
+                serialized = serialize_example(example)
+                tfrwriter.write(serialized)
+                save_count += 1
+                uf.print_progress_status(f"[generate_validation] index: {i}, count: {save_count}/{val_frames}")
+                if save_count % 100 == 10:
+                    show_example(example, 100, True)
+                elif save_count % 50 == 10:
+                    show_example(example, 100)
+
+            write_tfrecord_config(tfrpath, config, save_count)
+        pm.set_ok()
+    print("")
+
+
+def check_source_path(tfrpath):
+    if op.isdir(tfrpath.replace("_val", "_test")):
+        return tfrpath.replace("_val", "_test")
+    elif op.isdir(tfrpath.replace("_val", "_train")):
+        return tfrpath.replace("_val", "_train")
+    else:
+        print("!!! NO source dataset for validation split:", tfrpath)
+        return None
+
+
+def convert_to_np(tffeats):
+    npfeats = dict()
+    for key, value in tffeats.items():
+        if key.startswith("image5d"):
+            continue
+
+        if key.startswith("image"):
+            value = uf.to_uint8_image(value)
+        npfeats[key] = value[0].numpy()
+    return npfeats
+
+
+def write_tfrecord_config(tfrpath, cfg, example_count):
+    cfg["length"] = example_count
+    with open(op.join(tfrpath, "tfr_config.txt"), "w") as fr:
+        json.dump(cfg, fr)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tfrecords/validation_maker.py
+++ b/tfrecords/validation_maker.py
@@ -22,7 +22,7 @@ def generate_validation_tfrecords(tfrpath):
     val_frames = opts.VALIDATION_FRAMES
     stride = max(min(length // val_frames, 10), 1)
     save_count = 0
-    print("\n\n!!! Start create", op.basename(tfrpath))
+    print(f"\n\n!!! Start create \"{op.basename(tfrpath)}\"")
     print(f"source length={length}, stride={stride}, val_frames={val_frames}")
 
     with PathManager([tfrpath]) as pm:

--- a/utils/util_class.py
+++ b/utils/util_class.py
@@ -35,7 +35,8 @@ class PathManager:
         self.safe_exit = True
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.closer()
+        if self.closer:
+            self.closer()
         if self.safe_exit is False:
             print("[PathManager] the process is NOT ended properly, remove the working paths")
             for path in self.paths:


### PR DESCRIPTION
## create_tfrecords_main.py

기존에 prepare_data 결과를 이용했던 legacy 코드 제거
어떤 데이터셋의 train, test 데이터를 만들었다면 자동으로 이후 validation을 생성

## tfrecord_maker.py

TfrecordMakerSingleDir 자식 클래스에서 drive가 바뀔때마다 tfrecord를 새로 만드는 버그 찾아서 해결


## validation_maker.py

xxxTfrecordMaker에서 만든 test나 train tfrecord를 읽고 랜덤 샘플링으로 validation tfrecord 생성
