### PR TITLE
Improve config to handle diverse datasets / Improve logging

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -61,9 +61,9 @@ class VodeOptions(FixedOptions):
                            }
     IMAGE_SIZES = {"kitti_raw": (128, 384),
                    "kitti_odom": (128, 384),
-                   "cityscapes": (196, 384),
+                   "cityscapes": (192, 384),
                    "waymo": (256, 384),
-                   "driving_stereo": (196, 384),
+                   "driving_stereo": (192, 384),
                    }
     # only when making small tfrecords to test training
     FRAME_PER_DRIVE = 100
@@ -89,35 +89,35 @@ class VodeOptions(FixedOptions):
     """
     training options
     """
-    CKPT_NAME = "vode2"
+    CKPT_NAME = "vode0"
     ENABLE_SHAPE_DECOR = False
     LOG_LOSS = True
     TRAIN_MODE = ["eager", "graph", "distributed"][1]
     SSIM_RATIO = 0.8
-    LOSS_WEIGHTS = {
+    LOSS_WEIGHTS_T1 = {
         "L1": (1. - SSIM_RATIO) * 1., "L1_R": (1. - SSIM_RATIO) * 1.,
         "SSIM": SSIM_RATIO * 0.5, "SSIM_R": SSIM_RATIO * 0.5,
         "smoothe": 1., "smoothe_R": 1.,
-        "stereo_L1": 0.01, "stereo_SSIM": 0.01,
-        "stereo_pose": 1.,
-        "flow_L2": 1., "flow_L2_R": 1.,
-        "flow_L2_reg": 4e-7
+        "stereoL1": 0.01, "stereoSSIM": 0.01,
+        "stereoPose": 1.,
+        "flowL2": 1., "flowL2_R": 1.,
+        "flow_reg": 4e-7
     }
     TRAINING_PLAN = [
         # pretraining first round
-        ("kitti_raw", 2, 0.0001),
-        ("kitti_odom", 2, 0.0001),
-        ("waymo", 2, 0.0001),
-        ("driving_stereo", 2, 0.0001),
-        ("cityscapes", 2, 0.0001),
+        ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T1),
+        ("kitti_odom",      2, 0.0001, LOSS_WEIGHTS_T1),
+        ("waymo",           2, 0.0001, LOSS_WEIGHTS_T1),
+        ("driving_stereo",  2, 0.0001, LOSS_WEIGHTS_T1),
+        ("cityscapes",      2, 0.0001, LOSS_WEIGHTS_T1),
         # pretraining second round
-        ("kitti_raw", 2, 0.0001),
-        ("kitti_odom", 2, 0.0001),
-        ("waymo", 2, 0.0001),
-        ("driving_stereo", 2, 0.0001),
-        ("cityscapes", 2, 0.0001),
+        ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T1),
+        ("kitti_odom",      2, 0.0001, LOSS_WEIGHTS_T1),
+        ("waymo",           2, 0.0001, LOSS_WEIGHTS_T1),
+        ("driving_stereo",  2, 0.0001, LOSS_WEIGHTS_T1),
+        ("cityscapes",      2, 0.0001, LOSS_WEIGHTS_T1),
         # fine tuning
-        ("kitti_raw", 2, 0.0001),
+        ("kitti_raw",       10, 0.0001, LOSS_WEIGHTS_T1),
     ]
 
     @classmethod

--- a/config-example.py
+++ b/config-example.py
@@ -9,7 +9,6 @@ RAW_DATA_PATHS = {
     "waymo": "/media/ian/IanBook/datasets/waymo",
     "driving_stereo": "/media/ian/IanBook/datasets/raw_zips/driving_stereo",
 }
-# RESULT_DATAPATH = "/home/ian/workspace/vode/vode-data"
 RESULT_DATAPATH = "/media/ian/IanBook/vode_data/vode_stereo_0815"
 
 

--- a/model/build_model/depth_net.py
+++ b/model/build_model/depth_net.py
@@ -170,7 +170,7 @@ class TempActivation:
 
 
 def test_build_model():
-    total_shape = opts.get_shape("BSHWC")
+    total_shape = opts.get_img_shape("BSHWC")
     depthnet = DepthNetFromPretrained(total_shape, TempActivation(), "NASNetMobile", True)()
     depthnet.summary()
     depth_ms = depthnet.output["depth_ms"]

--- a/model/build_model/model_factory.py
+++ b/model/build_model/model_factory.py
@@ -23,7 +23,7 @@ class ModelFactory:
                  stereo=opts.STEREO,
                  stereo_extrinsic=opts.STEREO_EXTRINSIC):
         self.global_batch = global_batch
-        S, H, W, C = opts.get_shape("SHWC", dataset)
+        S, H, W, C = opts.get_img_shape("SHWC", dataset)
         self.input_shape = (global_batch, S, H, W, C)
         self.net_names = net_names
         self.activation = depth_activation

--- a/model/build_model/model_factory.py
+++ b/model/build_model/model_factory.py
@@ -16,7 +16,6 @@ PRETRAINED_MODELS = ["MobileNetV2", "NASNetMobile", "DenseNet121", "VGG16", "Xce
 
 class ModelFactory:
     def __init__(self, dataset_cfg,
-                 dataset_name=opts.DATASET_TO_USE,
                  global_batch=opts.BATCH_SIZE,
                  net_names=opts.NET_NAMES,
                  depth_activation=opts.DEPTH_ACTIVATION,

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -2,29 +2,53 @@ from config import opts
 import model.loss_and_metric.losses as lm
 
 
-def loss_factory(loss_weights=opts.LOSS_WEIGHTS, stereo=opts.STEREO,
+def loss_factory(dataset_config, loss_weights=opts.LOSS_WEIGHTS, stereo=opts.STEREO,
                  weights_to_regularize=None, batch_size=opts.BATCH_SIZE):
     loss_pool = {"L1": lm.PhotometricLossMultiScale("L1"),
                  "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
                  "SSIM": lm.PhotometricLossMultiScale("SSIM"),
                  "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
-                 "flow_L2": lm.FlowWarpLossMultiScale("L2"),
-                 "flow_L2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
                  "smoothe": lm.SmoothenessLossMultiScale(),
                  "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
                  "stereo_L1": lm.StereoDepthLoss("L1"),
                  "stereo_SSIM": lm.StereoDepthLoss("SSIM"),
                  "stereo_pose": lm.StereoPoseLoss(),
+                 "flow_L2": lm.FlowWarpLossMultiScale("L2"),
+                 "flow_L2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
                  "flow_L2_reg": lm.L2Regularizer(weights_to_regularize),
                  }
-
     losses = dict()
     weights = dict()
+
     for name, weight in loss_weights.items():
         if weight == 0.:
+            continue
+        if not check_loss_dependency(name, dataset_config):
             continue
         losses[name] = loss_pool[name]
         weights[name] = weight
 
     print("[loss_factory] loss weights:", weights)
     return lm.TotalLoss(losses, weights, stereo, batch_size)
+
+
+def check_loss_dependency(loss_key, dataset_config):
+    loss_dependency = [(["L1", "SSIM", "smoothe", "flow_L2", "flow_L2_reg"],
+                        ["image", "intrinsic"]),
+                       (["L1_R", "SSIM_R", "smoothe_R", "flow_L2_R"],
+                        ["image_R", "intrinsic_R"]),
+                       (["stereo_L1", "stereo_SSIM", "stereo_pose"],
+                        ["image", "intrinsic", "image_R", "intrinsic_R", "stereo_T_LR"])
+                       ]
+    # find dependency for loss_key
+    dependents = []
+    for loss_names, data_names in loss_dependency:
+        if loss_key in loss_names:
+            dependents = data_names
+    # check if dependents are in dataset
+    for dep in dependents:
+        if dep not in dataset_config:
+            print(f"[check_loss_dependency] {loss_key} loss is excluded because {dep} is NOT in dataset")
+            return False
+
+    return True

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -2,7 +2,7 @@ from config import opts
 import model.loss_and_metric.losses as lm
 
 
-def loss_factory(dataset_config, loss_weights=opts.LOSS_WEIGHTS, stereo=opts.STEREO,
+def loss_factory(dataset_cfg, loss_weights=opts.LOSS_WEIGHTS, stereo_cfg=opts.STEREO,
                  weights_to_regularize=None, batch_size=opts.BATCH_SIZE):
     loss_pool = {"L1": lm.PhotometricLossMultiScale("L1"),
                  "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
@@ -23,16 +23,16 @@ def loss_factory(dataset_config, loss_weights=opts.LOSS_WEIGHTS, stereo=opts.STE
     for name, weight in loss_weights.items():
         if weight == 0.:
             continue
-        if not check_loss_dependency(name, dataset_config):
+        if not check_loss_dependency(name, dataset_cfg):
             continue
         losses[name] = loss_pool[name]
         weights[name] = weight
 
     print("[loss_factory] loss weights:", weights)
-    return lm.TotalLoss(losses, weights, stereo, batch_size)
+    return lm.TotalLoss(losses, weights, stereo_cfg, batch_size)
 
 
-def check_loss_dependency(loss_key, dataset_config):
+def check_loss_dependency(loss_key, dataset_cfg):
     loss_dependency = [(["L1", "SSIM", "smoothe", "flow_L2", "flow_L2_reg"],
                         ["image", "intrinsic"]),
                        (["L1_R", "SSIM_R", "smoothe_R", "flow_L2_R"],
@@ -47,7 +47,7 @@ def check_loss_dependency(loss_key, dataset_config):
             dependents = data_names
     # check if dependents are in dataset
     for dep in dependents:
-        if dep not in dataset_config:
+        if dep not in dataset_cfg:
             print(f"[check_loss_dependency] {loss_key} loss is excluded because {dep} is NOT in dataset")
             return False
 

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -10,12 +10,12 @@ def loss_factory(dataset_cfg, loss_weights=opts.LOSS_WEIGHTS, stereo_cfg=opts.ST
                  "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
                  "smoothe": lm.SmoothenessLossMultiScale(),
                  "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
-                 "stereo_L1": lm.StereoDepthLoss("L1"),
-                 "stereo_SSIM": lm.StereoDepthLoss("SSIM"),
-                 "stereo_pose": lm.StereoPoseLoss(),
-                 "flow_L2": lm.FlowWarpLossMultiScale("L2"),
-                 "flow_L2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
-                 "flow_L2_reg": lm.L2Regularizer(weights_to_regularize),
+                 "stereoL1": lm.StereoDepthLoss("L1"),
+                 "stereoSSIM": lm.StereoDepthLoss("SSIM"),
+                 "stereoPose": lm.StereoPoseLoss(),
+                 "flowL2": lm.FlowWarpLossMultiScale("L2"),
+                 "flowL2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
+                 "flow_reg": lm.L2Regularizer(weights_to_regularize),
                  }
     losses = dict()
     weights = dict()
@@ -33,11 +33,11 @@ def loss_factory(dataset_cfg, loss_weights=opts.LOSS_WEIGHTS, stereo_cfg=opts.ST
 
 
 def check_loss_dependency(loss_key, dataset_cfg):
-    loss_dependency = [(["L1", "SSIM", "smoothe", "flow_L2", "flow_L2_reg"],
+    loss_dependency = [(["L1", "SSIM", "smoothe", "flowL2", "flow_reg"],
                         ["image", "intrinsic"]),
-                       (["L1_R", "SSIM_R", "smoothe_R", "flow_L2_R"],
+                       (["L1_R", "SSIM_R", "smoothe_R", "flowL2_R"],
                         ["image_R", "intrinsic_R"]),
-                       (["stereo_L1", "stereo_SSIM", "stereo_pose"],
+                       (["stereoL1", "stereoSSIM", "stereoPose"],
                         ["image", "intrinsic", "image_R", "intrinsic_R", "stereo_T_LR"])
                        ]
     # find dependency for loss_key

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -2,7 +2,7 @@ from config import opts
 import model.loss_and_metric.losses as lm
 
 
-def loss_factory(dataset_cfg, loss_weights=opts.LOSS_WEIGHTS, stereo_cfg=opts.STEREO,
+def loss_factory(dataset_cfg, loss_weights, stereo=opts.STEREO,
                  weights_to_regularize=None, batch_size=opts.BATCH_SIZE):
     loss_pool = {"L1": lm.PhotometricLossMultiScale("L1"),
                  "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
@@ -29,7 +29,7 @@ def loss_factory(dataset_cfg, loss_weights=opts.LOSS_WEIGHTS, stereo_cfg=opts.ST
         weights[name] = weight
 
     print("[loss_factory] loss weights:", weights)
-    return lm.TotalLoss(losses, weights, stereo_cfg, batch_size)
+    return lm.TotalLoss(losses, weights, stereo, batch_size)
 
 
 def check_loss_dependency(loss_key, dataset_cfg):

--- a/model/loss_and_metric/losses.py
+++ b/model/loss_and_metric/losses.py
@@ -34,11 +34,12 @@ class TotalLoss:
                 losses: list of losses computed from loss_objects
         """
         augm_data = self.append_data(features, predictions)
-        if self.stereo:
+        if self.stereo and ("image_R" in features):
             augm_data_rig = self.append_data(features, predictions, "_R")
             augm_data.update(augm_data_rig)
-            augm_data_stereo = self.synethesize_stereo(features, predictions, augm_data)
-            augm_data.update(augm_data_stereo)
+            if self.stereo and ("stereo_T_LR" in features):
+                augm_data_stereo = self.synethesize_stereo(features, predictions, augm_data)
+                augm_data.update(augm_data_stereo)
 
         losses = []
         loss_by_type = dict()

--- a/model/loss_and_metric/test_loss.py
+++ b/model/loss_and_metric/test_loss.py
@@ -137,7 +137,7 @@ def test_photo_loss(source_image, intrinsic, depth_gt_ms, pose_gt, target_ms):
         losses.append(loss)
         if scale == 1:
             recon_target = uf.to_uint8_image(synt_target).numpy()
-            recon_image = cv2.resize(recon_target[0, 0], opts.get_shape("WH"), interpolation=cv2.INTER_NEAREST)
+            recon_image = cv2.resize(recon_target[0, 0], opts.get_img_shape("WH"), interpolation=cv2.INTER_NEAREST)
 
     losses = tf.stack(losses, axis=2)   # [batch, numsrc, num_scales]
     batch_loss = tf.reduce_sum(losses, axis=[1, 2])
@@ -180,7 +180,7 @@ def test_smootheness_loss_quantity():
         stacked_image = features["image"]
         depth_gt = features["depth_gt"]
         # interpolate depth
-        height, width = opts.get_shape("HW")
+        height, width = opts.get_img_shape("HW")
         depth_gt = tf.image.resize(depth_gt, size=(height//2, width//2), method="bilinear")
         depth_gt = tf.image.resize(depth_gt, size=(height, width), method="bilinear")
         # make multi-scale data

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -39,7 +39,7 @@ def train(dataset_name, target_epoch, learning_rate):
         print("save intermediate results ...")
         log.save_reconstruction_samples(model, dataset_val, val_steps, epoch)
         save_model(model, result_val)
-        log.save_log(epoch, result_train, result_val)
+        log.save_log(epoch, dataset_name, result_train, result_val)
 
 
 def set_configs():

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -24,11 +24,9 @@ def train(final_epoch=opts.EPOCHS):
 
     set_configs()
     log.copy_or_check_same()
-    model, augmenter, loss_object, optimizer = create_training_parts(initial_epoch)
-
-    # TODO WARNING! using "test" split for training dataset is just to check training process
-    dataset_train, train_steps = get_dataset(opts.DATASET_TO_USE, "train", True)
-    dataset_val, val_steps = get_dataset(opts.DATASET_TO_USE, "val", False)
+    dataset_train, tfr_config, train_steps = get_dataset(opts.DATASET_TO_USE, "train", True)
+    dataset_val, _, val_steps = get_dataset(opts.DATASET_TO_USE, "val", False)
+    model, augmenter, loss_object, optimizer = create_training_parts(initial_epoch, tfr_config)
     trainer, validater = tv.train_val_factory(opts.TRAIN_MODE, model, loss_object,
                                               train_steps, opts.STEREO, augmenter, optimizer)
 
@@ -64,13 +62,13 @@ def set_configs():
 
 
 @StrategyScope
-def create_training_parts(initial_epoch):
+def create_training_parts(initial_epoch, tfr_config):
     pretrained_weight = (initial_epoch == 0) and opts.PRETRAINED_WEIGHT
     model = ModelFactory(global_batch=opts.BATCH_SIZE, pretrained_weight=pretrained_weight).get_model()
     model = try_load_weights(model)
     model.compile(optimizer='sgd', loss='mean_absolute_error')
     augmenter = augmentation_factory(opts.AUGMENT_PROBS)
-    loss_object = loss_factory(weights_to_regularize=model.weights_to_regularize())
+    loss_object = loss_factory(tfr_config, weights_to_regularize=model.weights_to_regularize())
     optimizer = optimizer_factory(opts.OPTIMIZER, opts.LEARNING_RATE, initial_epoch)
     return model, augmenter, loss_object, optimizer
 
@@ -90,9 +88,11 @@ def get_dataset(dataset_name, split, shuffle):
     batch_size = opts.BATCH_SIZE
     tfr_train_path = op.join(opts.DATAPATH_TFR, f"{dataset_name}_{split}")
     assert op.isdir(tfr_train_path)
-    dataset = TfrecordReader(tfr_train_path, shuffle=shuffle, batch_size=batch_size).get_dataset()
+    tfr_reader = TfrecordReader(tfr_train_path, shuffle=shuffle, batch_size=batch_size)
+    dataset = tfr_reader.get_dataset()
+    tfr_config = tfr_reader.get_tfr_config()
     steps_per_epoch = uf.count_steps(tfr_train_path, batch_size)
-    return dataset, steps_per_epoch
+    return dataset, tfr_config, steps_per_epoch
 
 
 def save_model(model, results_val):

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -64,7 +64,7 @@ def set_configs():
 @StrategyScope
 def create_training_parts(initial_epoch, tfr_config):
     pretrained_weight = (initial_epoch == 0) and opts.PRETRAINED_WEIGHT
-    model = ModelFactory(global_batch=opts.BATCH_SIZE, pretrained_weight=pretrained_weight).get_model()
+    model = ModelFactory(tfr_config, global_batch=opts.BATCH_SIZE, pretrained_weight=pretrained_weight).get_model()
     model = try_load_weights(model)
     model.compile(optimizer='sgd', loss='mean_absolute_error')
     augmenter = augmentation_factory(opts.AUGMENT_PROBS)

--- a/model/model_util/augmentation.py
+++ b/model/model_util/augmentation.py
@@ -367,7 +367,7 @@ def test_augmentations():
 
         ori_images = []
         raw_image_u8 = to_uint8_image(features["image"])
-        ori_images.append(raw_image_u8[0, -opts.get_shape("H"):])
+        ori_images.append(raw_image_u8[0, -opts.get_img_shape("H"):])
         source_image, synth_target = synthesize_target(features)
         ori_images.append(synth_target)
         ori_images.append(source_image)

--- a/model/model_util/augmentation.py
+++ b/model/model_util/augmentation.py
@@ -154,7 +154,8 @@ class HorizontalFlip(AugmentBase):
         if "intrinsic_R" in features:
             feat_aug["intrinsic_R"] = self.flip_intrinsic(features["intrinsic_R"], features["image5d"].get_shape())
 
-        feat_aug["pose_gt"] = self.flip_gt_pose(features["pose_gt"])
+        if "pose_gt" in features:
+            feat_aug["pose_gt"] = self.flip_gt_pose(features["pose_gt"])
         if "pose_gt_R" in features:
             feat_aug["pose_gt_R"] = self.flip_gt_pose(features["pose_gt_R"])
 

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -37,7 +37,18 @@ def save_log(epoch, dataset_name, results_train, results_val):
 
 
 def save_results(epoch, dataset_name, results_train, results_val, columns, filename):
-    # make column widths fixed, all widths are fixed to 6 characters except for epoch and dataset
+    """
+    저장된 csv 파일에서 하나의 column 너비는 가급적 6 글자가 되도록 맞춘다.
+    예시:
+        epoch,dataset,:loss ,:TE   ,:RE   ,  |   ,!loss ,!TE   ,!RE
+        0    ,kitti_r,1.9476,1.3867,0.0130,  |   ,1.1700,0.2056,0.0065
+        1    ,kitti_r,1.8911,1.3442,0.0129,  |   ,1.1845,0.2120,0.0051
+
+    - column 이름에서 ':'는 training 결과를 말하고 '!'는 validation 결과를 뜻한다.
+    - 6글자에 맞추기 위해 단어들을 줄여서 썼는데 약자들은 상단의 RENAMER나
+      checkpts의 how-to-read-columns.txt 에서도 확인할 수 있다.
+    - smootheness loss나 regularization loss는 크기가 작아서 1000을 곱해서 저장한다.
+    """
     train_result = results_train.mean(axis=0).to_dict()
     val_result = results_val.mean(axis=0).to_dict()
 

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -6,71 +6,106 @@ import cv2
 import tensorflow as tf
 import importlib
 import shutil
+import copy
+import json
 
 from config import opts
 import utils.util_funcs as uf
 import model.loss_and_metric.losses as lm
 
+RENAMER = {"trjerr": "TE", "roterr": "RE", "depth": "de",
+           "SSIM": "SS", "smoothe": "sm", "pose": "ps", "stereo": "st", "flow": "fl",
+           "stereoPose": "stps", "_reg": "Rg", "_R": "R"}
+TRAIN_PREFIX = ":"
+VALID_PREFIX = "!"
 
-def save_log(epoch, results_train, results_val):
+
+def save_log(epoch, dataset_name, results_train, results_val):
     """
-    :param epoch: current epoch
+    :param epoch:
+    :param dataset_name:
     :param results_train: dict of losses, metrics and depths from training data
     :param results_val: dict of losses, metrics and depths from validation data
     """
     summ_cols = ["loss", "trjerr", "roterr"]
-    summary = save_results(epoch, results_train, results_val, summ_cols, "history.csv")
+    summary = save_results(epoch, dataset_name, results_train, results_val, summ_cols, "history.csv")
     other_cols = [colname for colname in results_train.keys() if colname not in summ_cols]
-    _ = save_results(epoch, results_train, results_val, other_cols, "mean_result.csv")
+    _ = save_results(epoch, dataset_name, results_train, results_val, other_cols, "mean_result.csv")
 
     save_scales(epoch, results_train, results_val, "scales.txt")
     draw_and_save_plot(summary, "history.png")
 
 
-def save_results(epoch, results_train, results_val, columns, filename):
+def save_results(epoch, dataset_name, results_train, results_val, columns, filename):
     train_result = results_train.mean(axis=0).to_dict()
     val_result = results_val.mean(axis=0).to_dict()
-    epoch_result = {"epoch": epoch}
+
+    epoch_result = {"epoch": f"{epoch:<5}", "dataset": dataset_name[:7]}
     for colname in columns:
-        epoch_result["t_" + colname] = train_result[colname]
-    epoch_result["|"] = "|"
+        epoch_result[TRAIN_PREFIX + colname] = train_result[colname]
+    seperator = "  |   "
+    epoch_result[seperator] = seperator
     for colname in columns:
-        epoch_result["v_" + colname] = val_result[colname]
+        epoch_result[VALID_PREFIX + colname] = val_result[colname]
+    epoch_result = to_fixed_width_column(epoch_result)
+
+    # save "how-to-read-columns.json"
+    renamerfile = op.join(opts.DATAPATH_CKP, opts.CKPT_NAME, "how-to-read-columns.json")
+    if not op.isfile(renamerfile):
+        with open(renamerfile, "w") as fw:
+            json.dump(RENAMER, fw, separators=(',\n', ': '))
+            fw.write("\nsmootheness loss and flow reguluarization loss are scaled up to x1000\n")
 
     filepath = op.join(opts.DATAPATH_CKP, opts.CKPT_NAME, filename)
     # if the file existed, append new data to it
     if op.isfile(filepath):
-        existing = pd.read_csv(filepath, encoding='utf-8', converters={'epoch': lambda c: int(c)})
+        existing = pd.read_csv(filepath, encoding='utf-8', converters={'epoch': lambda c: f"{int(c):<5}"})
         results = existing.append(epoch_result, ignore_index=True)
         results = results.drop_duplicates(subset='epoch', keep='last')
+        results = results.fillna(0.)
+        # reorder columns
+        train_cols = [col for col in list(results) if col.startswith(TRAIN_PREFIX)]
+        val_cols = [col for col in list(results) if col.startswith(VALID_PREFIX)]
+        columns = ["epoch", "dataset"] + train_cols + [seperator] + val_cols
+        results = results.loc[:, columns]
         results = results.sort_values(by=['epoch'])
     else:
         results = pd.DataFrame([epoch_result])
 
-    # reorder columns
-    all_loss_cols = list(opts.LOSS_WEIGHTS.keys())
-    loss_cols = [col for col in columns if col in all_loss_cols]
-    other_cols = [col for col in columns if col not in all_loss_cols]
-    split_cols = loss_cols + other_cols
-    train_cols = ["t_" + col for col in split_cols]
-    val_cols = ["v_" + col for col in split_cols]
-    total_cols = ["epoch"] + train_cols + ["|"] + val_cols
-    results = results.loc[:, total_cols]
-
     # write to a file
-    results['epoch'] = results['epoch'].astype(int)
     results.to_csv(filepath, encoding='utf-8', index=False, float_format='%.4f')
     print(f"write {filename}\n", results.tail())
     return results
+
+
+def to_fixed_width_column(srcdict):
+    # scale up small values
+    middict = copy.deepcopy(srcdict)
+    for key, val in srcdict.items():
+        if "smooth" in key.lower() or "reg" in key.lower():
+            middict[key] = val * 1000.
+
+    # rename keys to shorter strings
+    dstdict = dict()
+    for key, val in middict.items():
+        newkey = copy.deepcopy(key)
+        for old, new in RENAMER.items():
+            if old in newkey:
+                newkey = newkey.replace(old, new)
+
+        if (newkey != "epoch") and (newkey != "dataset"):
+            newkey = f"{newkey[:6]:<6}"
+        dstdict[newkey] = val
+    return dstdict
 
 
 def draw_and_save_plot(results, filename):
     # plot graphs of loss and metrics
     fig, axes = plt.subplots(3, 1)
     fig.set_size_inches(7, 7)
-    for i, ax, colname, title in zip(range(3), axes, ['loss', 'trjerr', 'roterr'], ['Loss', 'Trajectory Error', 'Rotation Error']):
-        ax.plot(results['epoch'], results['t_' + colname], label='train_' + colname)
-        ax.plot(results['epoch'], results['v_' + colname], label='val_' + colname)
+    for i, ax, colname, title in zip(range(3), axes, ['loss ', 'TE   ', 'RE   '], ['Loss', 'Trajectory Error', 'Rotation Error']):
+        ax.plot(results['epoch'].astype(int), results[TRAIN_PREFIX + colname], label='train_' + colname)
+        ax.plot(results['epoch'].astype(int), results[VALID_PREFIX + colname], label='val_' + colname)
         ax.set_xlabel('epoch')
         ax.set_ylabel(colname)
         ax.set_title(title)

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -165,17 +165,18 @@ def copy_or_check_same():
     if opts.DATAPATH_CKP not in sys.path:
         sys.path.append(opts.DATAPATH_CKP)
     print(sys.path)
-    class_path = opts.CKPT_NAME + ".saved_config" + ".VodeOptions"
+    class_path = opts.CKPT_NAME + ".saved_config" + ".FixedOptions"
     module_name, class_name = class_path.rsplit('.', 1)
     module_obj = importlib.import_module(module_name)
     SavedOptions = getattr(module_obj, class_name)
-    from config import VodeOptions as CurrOptions
+    from config import FixedOptions as CurrOptions
 
     saved_opts = {attr: SavedOptions.__dict__[attr] for attr in SavedOptions.__dict__ if
                   not callable(getattr(SavedOptions, attr)) and not attr.startswith('__')}
     curr_opts = {attr: CurrOptions.__dict__[attr] for attr in CurrOptions.__dict__ if
                  not callable(getattr(CurrOptions, attr)) and not attr.startswith('__')}
-
+    print("saved_opts", saved_opts)
+    print("curr_opts", curr_opts)
     dont_care_opts = ["BATCH_SIZE", "EPOCHS", "LEARNING_RATE", "ENABLE_SHAPE_DECOR",
                       "CKPT_NAME", "LOG_LOSS", "PROJECT_ROOT", "DATASET", "TRAIN_MODE", "LOSS_WEIGHTS"]
 

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -175,14 +175,8 @@ def copy_or_check_same():
                   not callable(getattr(SavedOptions, attr)) and not attr.startswith('__')}
     curr_opts = {attr: CurrOptions.__dict__[attr] for attr in CurrOptions.__dict__ if
                  not callable(getattr(CurrOptions, attr)) and not attr.startswith('__')}
-    print("saved_opts", saved_opts)
-    print("curr_opts", curr_opts)
-    dont_care_opts = ["BATCH_SIZE", "EPOCHS", "LEARNING_RATE", "ENABLE_SHAPE_DECOR",
-                      "CKPT_NAME", "LOG_LOSS", "PROJECT_ROOT", "DATASET", "TRAIN_MODE", "LOSS_WEIGHTS"]
 
     for key, saved_val in saved_opts.items():
-        if key in dont_care_opts:
-            continue
         curr_val = curr_opts[key]
         assert saved_val == curr_val, f"key: {key}, {curr_val} != {saved_val}"
 

--- a/model/synthesize/flow_warping.py
+++ b/model/synthesize/flow_warping.py
@@ -87,14 +87,14 @@ def test_reshape_source_images():
     print("src_img shape", bat_img.shape)
 
     # take only left image
-    left_img = bat_img[:, :, :opts.get_shape("W")]
+    left_img = bat_img[:, :, :opts.get_img_shape("W")]
     print("left_img shape", left_img.shape)
     cv2.imshow("left_img", left_img[0].numpy().astype(np.uint8))
     cv2.waitKey(10)
 
     # reshape image
     batch = 3
-    numsrc, height, width = opts.get_shape("SHC")
+    numsrc, height, width = opts.get_img_shape("SHC")
 
     # EXECUTE
     rsp_img = tf.reshape(left_img, (batch*numsrc, height, width, 3))

--- a/model/synthesize/test_synthesizing.py
+++ b/model/synthesize/test_synthesizing.py
@@ -46,8 +46,8 @@ def test_synthesize_batch_multi_scale():
         source_image = uf.to_uint8_image(source_image).numpy()[0, 0]
         recon_img0 = uf.to_uint8_image(synth_target_ms[0]).numpy()[0, 0]
         recon_img1 = uf.to_uint8_image(synth_target_ms[2]).numpy()[0, 0]
-        print("recon image size:", recon_img0.shape, recon_img1.shape, opts.get_shape("WH", dataname))
-        recon_img1 = cv2.resize(recon_img1, opts.get_shape("WH", dataname), cv2.INTER_NEAREST)
+        print("recon image size:", recon_img0.shape, recon_img1.shape, opts.get_img_shape("WH", dataname))
+        recon_img1 = cv2.resize(recon_img1, opts.get_img_shape("WH", dataname), cv2.INTER_NEAREST)
         view = np.concatenate([source_image, target_image, recon_img0, recon_img1], axis=0)
         print("Check if all the images are the same")
         cv2.imshow("source, target, and reconstructed", view)
@@ -132,7 +132,7 @@ def test_reshape_source_images():
     print("reorganized source image shape", reshaped_image.get_shape().as_list())
     reshaped_image = uf.to_uint8_image(reshaped_image).numpy()
     imgidx = 2
-    scsize = opts.get_shape("HW", scale_div=2)
+    scsize = opts.get_img_shape("HW", scale_div=2)
     scaled_image = tf.image.resize(source_image, size=(scsize[0]*4, scsize[1]), method="bilinear")
     scaled_image = uf.to_uint8_image(scaled_image).numpy()
     scaled_image = scaled_image[0, scsize[0]*imgidx:scsize[0]*(imgidx+1)]

--- a/model/train_val.py
+++ b/model/train_val.py
@@ -211,7 +211,8 @@ def inspect_model(preds, features, step, steps_per_epoch):
     # pose: [batch, numsrc, 6]
     print("pose_pr", preds["pose"][0, 0, :3].numpy(), preds["pose"][0, 1, :3].numpy())
     # pose_gt: [batch, numsrc, 4, 4]
-    print("pose_gt", features["pose_gt"][0, 0, :3, 3].numpy(), features["pose_gt"][0, 1, :3, 3].numpy())
+    if "pose_gt" in features:
+        print("pose_gt", features["pose_gt"][0, 0, :3, 3].numpy(), features["pose_gt"][0, 1, :3, 3].numpy())
     if "pose_LR" in preds:
         # pose: [batch, numsrc, 6]
         print("T_LR_pr", preds["pose_LR"][0, 0, :3].numpy(), preds["pose_LR"][0, 1, :3].numpy())

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -29,7 +29,7 @@ def convert_to_tfrecords_directly():
 
 
 def tfrecord_maker_factory(dataset, split, srcpath, tfrpath):
-    dstshape = opts.get_shape("SHWC", dataset.split('__')[0])
+    dstshape = opts.get_img_shape("SHWC", dataset.split('__')[0])
     if dataset == "kitti_raw":
         return tm.KittiRawTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
     elif dataset == "kitti_odom":

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -136,7 +136,7 @@ class ExampleMaker:
                 return dict()   # empty dict means skip this frame
 
             max_dist = np.max(distances)
-            if max_dist > 5.:
+            if max_dist > 10.:
                 print("\n  Change scene? distance=", max_dist)
                 return dict()   # empty dict means skip this frame
         return example

--- a/tfrecords/readers/city_reader.py
+++ b/tfrecords/readers/city_reader.py
@@ -147,7 +147,7 @@ def test_city_reader():
             extrinsic = reader.get_stereo_extrinsic(fi)
             print("intrinsic\n", intrinsic)
             print("extrinsic\n", extrinsic)
-            depth = reader.get_depth(fi, image.shape[:2], opts.get_shape("HW", "cityscapes"), intrinsic)
+            depth = reader.get_depth(fi, image.shape[:2], opts.get_img_shape("HW", "cityscapes"), intrinsic)
             print(f"== test_city_reader) drive: {op.basename(drive_path)}, frame: {fi}")
             view = image[0:-1:5, 0:-1:5, :]
             depth_view = apply_color_map(depth)

--- a/tfrecords/readers/driving_reader.py
+++ b/tfrecords/readers/driving_reader.py
@@ -119,7 +119,7 @@ def test_driving_stereo_reader():
         for fi in frame_indices:
             image = reader.get_image(fi)
             intrinsic = reader.get_intrinsic(fi)
-            depth = reader.get_depth(fi, image.shape[:2], opts.get_shape("HW", "cityscapes"), intrinsic)
+            depth = reader.get_depth(fi, image.shape[:2], opts.get_img_shape("HW", "cityscapes"), intrinsic)
             print(f"== test_city_reader) drive: {op.basename(drive_path)}, frame: {fi}")
             view = image
             depth_view = apply_color_map(depth)

--- a/tfrecords/readers/kitti_reader.py
+++ b/tfrecords/readers/kitti_reader.py
@@ -352,7 +352,7 @@ def test_kitti_raw_reader():
             image_R = reader.get_image(fi, right=True)
             intrinsic = reader.get_intrinsic(fi)
             extrinsic = reader.get_stereo_extrinsic(fi)
-            depth = reader.get_depth(fi, image.shape[:2], opts.get_shape("HW", "kitti_raw"), intrinsic)
+            depth = reader.get_depth(fi, image.shape[:2], opts.get_img_shape("HW", "kitti_raw"), intrinsic)
             print(f"== test_kitti_raw_reader) drive: {drive_key}, frame id: {fi}")
             print("image size:", image.shape)
             print("intrinsic:\n", intrinsic)

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -175,7 +175,7 @@ def test_waymo_reader():
                 image = reader.get_image(fi)
                 pose = reader.get_pose(fi)
                 intrinsic = reader.get_intrinsic(fi)
-                depth = reader.get_depth(fi, image.shape[:2], opts.get_shape("HW", "waymo"), intrinsic)
+                depth = reader.get_depth(fi, image.shape[:2], opts.get_img_shape("HW", "waymo"), intrinsic)
             except StopIteration as si:
                 print("StopIteration:", si)
                 break

--- a/tfrecords/test_reader.py
+++ b/tfrecords/test_reader.py
@@ -37,7 +37,7 @@ def test_tfrecord_reader():
 
 
 def create_model():
-    input_shape = (opts.get_shape("H")*5, opts.get_shape("W"), 3)
+    input_shape = (opts.get_img_shape("H")*5, opts.get_img_shape("W"), 3)
     model = Sequential([
         Conv2D(16, 3, padding='same', activation='relu', input_shape=input_shape),
         MaxPooling2D(),

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -4,6 +4,7 @@ from glob import glob
 import tensorflow as tf
 import shutil
 import json
+import copy
 
 import utils.util_funcs as uf
 import utils.util_class as uc
@@ -104,7 +105,7 @@ class TfrecordMakerBase:
                         continue
 
                     example_serial = self.serialize_example(example)
-                    last_example = example
+                    last_example = copy.deepcopy(example)
                     self.write_tfrecord(example_serial, di)
                     uf.print_progress_status(f"==[making TFR] drive: {di}/{num_drives}, "
                                              f"frame: {ii}/{num_frames}, "

--- a/tfrecords/tfrecord_reader.py
+++ b/tfrecords/tfrecord_reader.py
@@ -107,6 +107,8 @@ class TfrecordReader:
     def get_total_steps(self):
         return self.config["length"] // self.batch_size
 
+    def get_tfr_config(self):
+        return self.config
 
 # --------------------------------------------------------------------------------
 # TESTS

--- a/tfrecords/validation_maker.py
+++ b/tfrecords/validation_maker.py
@@ -30,7 +30,7 @@ def generate_validation_tfrecords(tfrpath, val_frames):
             for i, features in enumerate(dataset):
                 if i % stride != 0:
                     continue
-                if i >= val_frames:
+                if save_count >= val_frames:
                     break
 
                 example = convert_to_np(features)

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -191,7 +191,7 @@ def multi_scale_like_flow(image, flow_ms):
 
 
 def stack_titled_images(view_imgs, guide_lines=True):
-    dsize = opts.get_shape("HW")
+    dsize = opts.get_img_shape("HW")
     location = (20, 20)
     font = cv2.FONT_HERSHEY_SIMPLEX
     font_scale = 0.5

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -191,7 +191,8 @@ def multi_scale_like_flow(image, flow_ms):
 
 
 def stack_titled_images(view_imgs, guide_lines=True):
-    dsize = opts.get_img_shape("HW")
+    # resize all images to the first image size
+    hw_size = view_imgs[list(view_imgs.keys())[0]].get_shape()[:2]
     location = (20, 20)
     font = cv2.FONT_HERSHEY_SIMPLEX
     font_scale = 0.5
@@ -200,7 +201,7 @@ def stack_titled_images(view_imgs, guide_lines=True):
     view = []
 
     for name, flimage in view_imgs.items():
-        flimage_rsz = tf.image.resize(flimage, size=dsize, method="nearest")
+        flimage_rsz = tf.image.resize(flimage, size=hw_size, method="nearest")
         u8image = to_uint8_image(flimage_rsz).numpy()
         if u8image.shape[-1] == 1:
             u8image = cv2.cvtColor(u8image, cv2.COLOR_GRAY2BGR)


### PR DESCRIPTION
## FixedOptions in config.py

VodeOptions에서 training 하는동안 고정되어야 하는 옵션은 FixedOptions라는 클래스로 이동하고 
VodeOptions가 FixedOptions를 상속받음
copy_or_check_same() 함수에서는 FixedOptions만 바뀌었는지 검사함

## TRAINING_PLAN in config.py

TRAINING_PLAN이란 옵션에 단계별로 학습할 dataset, epoch, learning_rate, loss_weights를 
묶어서 저장해두고 
model_main.py의 train_by_plan() 함수에서 이 순서대로 학습을 진행함

## Different image shape

데이터셋의 이미지 사이즈가 달라져도 돌아갈수 있도록 수정
특히 collect_pretrained_outputs.py, pretrained_nets.py 에서 
nasnet, xception의 입력 사이즈를 이미지 사이즈에 맞게 자동으로 맞추도록 조정

## loss_factory.py, losses.py

opts.STEREO는 stereo 데이터를 활용할지 선택하는 옵션인데 
opts.STEREO=True일지라도 데이터셋이 monocular라면 
stereo 관련한 데이터를 만들거나 loss를 사용하지 않도록 함

## model_main.py

TRAINING_PLAN의 dataset, epoch, learning_rate, loss_weights 정보를 필요한 함수에 분배
opts에 들어있는 고정값을 쓰기보다는 입력인자로 받아서 변하는 데이터에 맞춰서 처리

## logger.py

학습한 과정을 history.csv나 mean_results.csv에 저장하는데 column 이름과 아래 값들의 너비가 
맞지 않아서 읽기가 힘들었는데 똑같이 6글자로 맞춰서 csv 파일을 읽기 쉽게 만듦
