### PR TITLE
Improve loss handle dynamic

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -22,6 +22,16 @@ class FixedOptions:
     MIN_DEPTH = 1e-3
     MAX_DEPTH = 80
 
+    IMAGE_SIZES = {"kitti_raw": (128, 512),
+                   "kitti_odom": (128, 512),
+                   "cityscapes": (192, 384),
+                   "waymo": (256, 384),
+                   "driving_stereo": (192, 384),
+                   }
+    IMAGE_CROP = {"kitti_raw": True,
+                  "kitti_odom": True,
+                  }
+
     """
     training options
     """
@@ -57,14 +67,8 @@ class VodeOptions(FixedOptions):
                            "cityscapes__extra": ["train"],
                            "cityscapes__sequence": ["train"],
                            "waymo": ["train"],
-                           "driving_stereo": ["train", "test"],
+                           # "driving_stereo": ["train", "test"],
                            }
-    IMAGE_SIZES = {"kitti_raw": (128, 384),
-                   "kitti_odom": (128, 384),
-                   "cityscapes": (192, 384),
-                   "waymo": (256, 384),
-                   "driving_stereo": (192, 384),
-                   }
     # only when making small tfrecords to test training
     FRAME_PER_DRIVE = 100
     TOTAL_FRAME_LIMIT = 500
@@ -89,7 +93,7 @@ class VodeOptions(FixedOptions):
     """
     training options
     """
-    CKPT_NAME = "vode0"
+    CKPT_NAME = "vode1"
     ENABLE_SHAPE_DECOR = False
     LOG_LOSS = True
     TRAIN_MODE = ["eager", "graph", "distributed"][1]
@@ -103,18 +107,27 @@ class VodeOptions(FixedOptions):
         "flowL2": 1., "flowL2_R": 1.,
         "flow_reg": 4e-7
     }
+    LOSS_WEIGHTS_T2 = {
+        "md2L1": (1. - SSIM_RATIO) * 1., "md2L1_R": (1. - SSIM_RATIO) * 1.,
+        "md2SSIM": SSIM_RATIO * 0.5, "md2SSIM_R": SSIM_RATIO * 0.5,
+        "cmbL1": (1. - SSIM_RATIO) * 1., "cmbL1_R": (1. - SSIM_RATIO) * 1.,
+        "cmbSSIM": SSIM_RATIO * 0.5, "cmbSSIM_R": SSIM_RATIO * 0.5,
+        "smoothe": 1., "smoothe_R": 1.,
+        "stereoL1": 0.01, "stereoSSIM": 0.01,
+        "stereoPose": 1.,
+        "flowL2": 1., "flowL2_R": 1.,
+        "flow_reg": 4e-7
+    }
     TRAINING_PLAN = [
         # pretraining first round
-        ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T1),
+        ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T2),
         ("kitti_odom",      2, 0.0001, LOSS_WEIGHTS_T1),
         ("waymo",           2, 0.0001, LOSS_WEIGHTS_T1),
-        ("driving_stereo",  2, 0.0001, LOSS_WEIGHTS_T1),
         ("cityscapes",      2, 0.0001, LOSS_WEIGHTS_T1),
         # pretraining second round
         ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T1),
         ("kitti_odom",      2, 0.0001, LOSS_WEIGHTS_T1),
         ("waymo",           2, 0.0001, LOSS_WEIGHTS_T1),
-        ("driving_stereo",  2, 0.0001, LOSS_WEIGHTS_T1),
         ("cityscapes",      2, 0.0001, LOSS_WEIGHTS_T1),
         # fine tuning
         ("kitti_raw",       10, 0.0001, LOSS_WEIGHTS_T1),

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -6,6 +6,8 @@ def loss_factory(dataset_cfg, loss_weights, stereo=opts.STEREO,
                  weights_to_regularize=None, batch_size=opts.BATCH_SIZE):
     loss_pool = {"L1": lm.PhotometricLossMultiScale("L1"),
                  "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
+                 "md2": lm.MonoDepth2LossMultiScale("L1"),
+                 "md2_R": lm.MonoDepth2LossMultiScale("L1", key_suffix="_R"),
                  "SSIM": lm.PhotometricLossMultiScale("SSIM"),
                  "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
                  "smoothe": lm.SmoothenessLossMultiScale(),

--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -4,21 +4,31 @@ import model.loss_and_metric.losses as lm
 
 def loss_factory(dataset_cfg, loss_weights, stereo=opts.STEREO,
                  weights_to_regularize=None, batch_size=opts.BATCH_SIZE):
-    loss_pool = {"L1": lm.PhotometricLossMultiScale("L1"),
-                 "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
-                 "md2": lm.MonoDepth2LossMultiScale("L1"),
-                 "md2_R": lm.MonoDepth2LossMultiScale("L1", key_suffix="_R"),
-                 "SSIM": lm.PhotometricLossMultiScale("SSIM"),
-                 "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
-                 "smoothe": lm.SmoothenessLossMultiScale(),
-                 "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
-                 "stereoL1": lm.StereoDepthLoss("L1"),
-                 "stereoSSIM": lm.StereoDepthLoss("SSIM"),
-                 "stereoPose": lm.StereoPoseLoss(),
-                 "flowL2": lm.FlowWarpLossMultiScale("L2"),
-                 "flowL2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
-                 "flow_reg": lm.L2Regularizer(weights_to_regularize),
-                 }
+    loss_pool = {
+        "L1": lm.PhotometricLossMultiScale("L1"),
+        "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
+        "SSIM": lm.PhotometricLossMultiScale("SSIM"),
+        "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
+
+        "md2L1": lm.MonoDepth2LossMultiScale("L1"),
+        "md2L1_R": lm.MonoDepth2LossMultiScale("L1", key_suffix="_R"),
+        "md2SSIM": lm.MonoDepth2LossMultiScale("SSIM"),
+        "md2SSIM_R": lm.MonoDepth2LossMultiScale("SSIM", key_suffix="_R"),
+
+        "cmbL1": lm.CombinedLossMultiScale("L1"),
+        "cmbL1_R": lm.CombinedLossMultiScale("L1", key_suffix="_R"),
+        "cmbSSIM": lm.CombinedLossMultiScale("SSIM"),
+        "cmbSSIM_R": lm.CombinedLossMultiScale("SSIM", key_suffix="_R"),
+
+        "smoothe": lm.SmoothenessLossMultiScale(),
+        "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
+        "stereoL1": lm.StereoDepthLoss("L1"),
+        "stereoSSIM": lm.StereoDepthLoss("SSIM"),
+        "stereoPose": lm.StereoPoseLoss(),
+        "flowL2": lm.FlowWarpLossMultiScale("L2"),
+        "flowL2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
+        "flow_reg": lm.L2Regularizer(weights_to_regularize),
+    }
     losses = dict()
     weights = dict()
 

--- a/model/loss_and_metric/loss_util.py
+++ b/model/loss_and_metric/loss_util.py
@@ -90,8 +90,6 @@ def photometric_loss_ssim(synt_target, orig_target, reduce=True):
     ssim = ssim_n / ssim_d
     ssim = tf.clip_by_value((1 - ssim) / 2, 0, 1)
     ssim = tf.where(error_mask, tf.constant(0, dtype=tf.float32), ssim)
-    # average per example
-    ssim = tf.reduce_mean(ssim, axis=[1, 2, 3, 4])
 
     if reduce:  # reduce to average per example
         ssim = tf.reduce_mean(ssim, axis=[1, 2, 3, 4])

--- a/model/loss_and_metric/loss_util.py
+++ b/model/loss_and_metric/loss_util.py
@@ -3,10 +3,11 @@ from utils.decorators import shape_check
 
 
 @shape_check
-def photometric_loss_l1(synt_target, orig_target):
+def photometric_loss_l1(synt_target, orig_target, reduce=True):
     """
     :param synt_target: scaled synthesized target image [batch, numsrc, height/scale, width/scale, 3]
     :param orig_target: scaled original target image [batch, height/scale, width/scale, 3]
+    :param reduce: whether to reduce loss to batch size or not
     :return: photo_loss [batch]
     """
     orig_target = tf.expand_dims(orig_target, axis=1)
@@ -19,16 +20,17 @@ def photometric_loss_l1(synt_target, orig_target):
     # photo_error: [batch, numsrc, height/scale, width/scale, 3]
     photo_error = tf.abs(synt_target - orig_target)
     photo_error = tf.where(error_mask, tf.constant(0, dtype=tf.float32), photo_error)
-    # average per example
-    photo_loss = tf.reduce_mean(photo_error, axis=[1, 2, 3, 4])
-    return photo_loss
+    if reduce:  # reduce to average per example
+        photo_error = tf.reduce_mean(photo_error, axis=[1, 2, 3, 4])
+    return photo_error
 
 
 @shape_check
-def photometric_loss_l2(synt_target, orig_target):
+def photometric_loss_l2(synt_target, orig_target, reduce=True):
     """
     :param synt_target: scaled synthesized target image [batch, numsrc, height/scale, width/scale, 3]
     :param orig_target: scaled original target image [batch, height/scale, width/scale, 3]
+    :param reduce: whether to reduce loss to batch size or not
     :return: photo_loss [batch]
     """
     orig_target = tf.expand_dims(orig_target, axis=1)
@@ -41,16 +43,17 @@ def photometric_loss_l2(synt_target, orig_target):
     # photo_error: [batch, numsrc, height/scale, width/scale, 3]
     photo_error = tf.square(synt_target - orig_target)
     photo_error = tf.where(error_mask, tf.constant(0, dtype=tf.float32), photo_error)
-    # average per example
-    photo_loss = tf.reduce_mean(photo_error, axis=[1, 2, 3, 4])
-    return photo_loss
+    if reduce:  # reduce to average per example
+        photo_error = tf.reduce_mean(photo_error, axis=[1, 2, 3, 4])
+    return photo_error
 
 
 @shape_check
-def photometric_loss_ssim(synt_target, orig_target):
+def photometric_loss_ssim(synt_target, orig_target, reduce=True):
     """
     :param synt_target: scaled synthesized target image [batch, numsrc, height/scale, width/scale, 3]
     :param orig_target: scaled original target image [batch, height/scale, width/scale, 3]
+    :param reduce: whether to reduce loss to batch size or not
     :return: photo_loss [batch]
     """
     numsrc = synt_target.get_shape().as_list()[1]
@@ -89,4 +92,7 @@ def photometric_loss_ssim(synt_target, orig_target):
     ssim = tf.where(error_mask, tf.constant(0, dtype=tf.float32), ssim)
     # average per example
     ssim = tf.reduce_mean(ssim, axis=[1, 2, 3, 4])
+
+    if reduce:  # reduce to average per example
+        ssim = tf.reduce_mean(ssim, axis=[1, 2, 3, 4])
     return ssim

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -30,10 +30,11 @@ def convert_to_tfrecords_directly():
 
 def tfrecord_maker_factory(dataset, split, srcpath, tfrpath):
     dstshape = opts.get_img_shape("SHWC", dataset.split('__')[0])
+    crop = False if dataset not in opts.IMAGE_CROP else opts.IMAGE_CROP[dataset]
     if dataset == "kitti_raw":
-        return tm.KittiRawTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
+        return tm.KittiRawTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape, crop)
     elif dataset == "kitti_odom":
-        return tm.KittiOdomTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
+        return tm.KittiOdomTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape, crop)
     elif dataset.startswith("cityscapes"):
         return tm.CityscapesTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
     elif dataset is "waymo":

--- a/tfrecords/readers/city_reader.py
+++ b/tfrecords/readers/city_reader.py
@@ -1,6 +1,5 @@
 import os.path as op
 import numpy as np
-from glob import glob
 from PIL import Image
 import json
 
@@ -50,7 +49,6 @@ class CityscapesReader(DataReaderBase):
         return self.target_indices
 
     def get_image(self, index, right=False):
-        # assert right is False, "city dataset is monocular"
         if right:
             filename = self.frame_names[index].replace("leftImg8bit", "rightImg8bit")
             image_bytes = self.zip_files["rightImg"].open(filename)
@@ -64,7 +62,7 @@ class CityscapesReader(DataReaderBase):
         return None
 
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
-        # assert right is False, "city dataset is monocular"
+        if right: return None
         params = self._get_camera_param(index)
         baseline = params["extrinsic"]["baseline"]
         fx = params["intrinsic"]["fx"]
@@ -81,7 +79,6 @@ class CityscapesReader(DataReaderBase):
         return depth.astype(np.float32)
 
     def get_intrinsic(self, index=0, right=False):
-        # assert right is False, "city dataset is monocular"
         params = self._get_camera_param(index)
         fx = params["intrinsic"]["fx"]
         fy = params["intrinsic"]["fy"]

--- a/tfrecords/readers/city_reader.py
+++ b/tfrecords/readers/city_reader.py
@@ -120,6 +120,7 @@ class CityscapesReader(DataReaderBase):
         return param
 
 
+# ======================================================================
 import cv2
 from config import opts
 import zipfile

--- a/tfrecords/readers/driving_reader.py
+++ b/tfrecords/readers/driving_reader.py
@@ -79,6 +79,7 @@ class DrivingStereoReader(DataReaderBase):
         image_bytes = self.zip_files[zipkey].open(filename)
         image = Image.open(image_bytes)
         image = np.array(image, np.uint8)
+        image = image[:, :, [2, 1, 0]]
         return image
 
     def get_pose(self, index, right=False):
@@ -103,8 +104,10 @@ class DrivingStereoReader(DataReaderBase):
         return self.stereo_T_LR.copy()
 
 
+# ======================================================================
 import cv2
 from config import opts
+from utils.util_funcs import print_progress_status
 
 
 def test_driving_stereo_reader():
@@ -120,12 +123,17 @@ def test_driving_stereo_reader():
             image = reader.get_image(fi)
             intrinsic = reader.get_intrinsic(fi)
             depth = reader.get_depth(fi, image.shape[:2], opts.get_img_shape("HW", "cityscapes"), intrinsic)
-            print(f"== test_city_reader) drive: {op.basename(drive_path)}, frame: {fi}")
+
+            drive_path = op.basename(drive_path)
+            frame_name = op.basename(reader.frame_names[fi])
+            frame_name = frame_name.replace(op.basename(drive_path[:-4]), 'drive')
+            frame_name = frame_name.replace(op.basename(drive_path[:10]), 'date')
+            print(f"== test_city_reader) drive: {op.basename(drive_path)}, frame: {fi}, {frame_name}")
             view = image
             depth_view = apply_color_map(depth)
             cv2.imshow("image", view)
             cv2.imshow("dstdepth", depth_view)
-            key = cv2.waitKey(2000)
+            key = cv2.waitKey(0)
             if key == ord('q'):
                 break
 
@@ -172,6 +180,6 @@ def test_driving_stereo_synthesis():
 
 
 if __name__ == "__main__":
-    # test_driving_stereo_reader()
-    test_driving_stereo_synthesis()
+    test_driving_stereo_reader()
+    # test_driving_stereo_synthesis()
 

--- a/tfrecords/readers/kitti_reader.py
+++ b/tfrecords/readers/kitti_reader.py
@@ -333,7 +333,7 @@ class KittiOdomReader(DataReaderBase):
         return T_cam2_cam3
 
 
-
+# ======================================================================
 import cv2
 from config import opts
 

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -39,28 +39,28 @@ class WaymoReader(DataReaderBase):
         return range(2, self.num_frames_()-2)
 
     def get_image(self, index, right=False):
-        assert right is False, "waymo dataset is monocular"
+        if right: return None
         frame = self._get_frame(index)
         front_image = tf.image.decode_jpeg(frame.images[0].image)
         front_image = front_image.numpy()[:, :, [2, 1, 0]]  # rgb to bgr
         return front_image.astype(np.uint8)
 
     def get_pose(self, index, right=False):
-        assert right is False, "waymo dataset is monocular"
+        if right: return None
         frame = self._get_frame(index)
         pose_c2w = tf.reshape(frame.images[0].pose.transform, (4, 4)) @ T_C2V
         pose_c2w = pose_c2w.numpy()
         return pose_c2w.astype(np.float32)
 
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
-        assert right is False, "waymo dataset is monocular"
+        if right: return None
         frame = self._get_frame(index)
         depth = get_waymo_depth_map(frame, srcshape_hw, dstshape_hw, intrinsic)
         depth = depth[..., np.newaxis]
         return depth.astype(np.float32)
 
     def get_intrinsic(self, index=0, right=False):
-        assert right is False, "waymo dataset is monocular"
+        if right: return None
         frame = self._get_frame(index)
         intrin = frame.context.camera_calibrations[0].intrinsic
         intrin = np.array([[intrin[0], 0, intrin[2]], [0, intrin[1], intrin[3]], [0, 0, 1]])

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -157,6 +157,7 @@ def get_waymo_depth_map(frame, srcshape_hw, dstshape_hw, intrinsic):
     return depth_map
 
 
+# ======================================================================
 import cv2
 import utils.util_funcs as uf
 from config import opts
@@ -188,9 +189,11 @@ def test_waymo_reader():
             cv2.imshow("image", view)
             cv2.imshow("depth", depth)
             if dist < 5:
-                cv2.waitKey(10)
+                key = cv2.waitKey(10)
             else:
-                cv2.waitKey(2000)
+                key = cv2.waitKey(2000)
+            if key == ord('q'):
+                break
             pose_bef = pose
 
 

--- a/tfrecords/tfr_util.py
+++ b/tfrecords/tfr_util.py
@@ -18,7 +18,9 @@ class Serializer:
     def convert_to_feature(self, example_dict):
         features = dict()
         for key, value in example_dict.items():
-            if isinstance(value, np.ndarray):
+            if value is None:
+                continue
+            elif isinstance(value, np.ndarray):
                 features[key] = self._bytes_feature(value.tostring())
             elif isinstance(value, int):
                 features[key] = self._int64_feature(value)


### PR DESCRIPTION

## config.py

- IMAGE_CROP 추가: 어떤 데이터셋에서 image crop을 할 것인지 지정
- LOSS_WEIGHTS_T2: "MonoDepth2", "Combined" 등의 새로운 loss를 사용하는 type2 weight

## loss_factory.py

"MonoDepth2", "Combined" 등의 새로운 loss를 사용할 수 있도록 loss_pool 확장

## losses.py

- MonoDepth2LossMultiScale: monodepth2 논문의 loss를 구현
- CombinedLossMultiScale: 최근 논문에 나온 것처럼 rigid flow와 optical flow를 비교하여 낮은 쪽은 학습시키는 loss

## example_maker.py

crop=True 인자가 들어오면 이미지를 resize하기 전에 aspect ratio를 유지하도록 이미지를 자른다.

## tfrecord_maker.py

get_dataset_keys()에서 데이터셋마다 일일이 불러올수 있는 데이터 키를 지정해주지 않고 
그냥 모든 key를 다 지정한 다음 example을 받았을 때 None이 들어있으면 
Serializer에서 제외시키도록 수정 
