### PR TITLE
A2d2 reader

### DIFF
--- a/evaluate/evaluate_main.py
+++ b/evaluate/evaluate_main.py
@@ -9,37 +9,6 @@ import utils.util_funcs as uf
 import evaluate.eval_funcs as ef
 
 
-def evaluate_by_user_interaction():
-    options = {"data_dir_name": "kitti_raw_test",
-               "model_name": "vode_model",
-               }
-
-    print("\n===== Select evaluation options")
-
-    print(f"Default options:")
-    for key, value in options.items():
-        print(f"\t{key} = {value}")
-    print("\nIf you are happy with default options, please press enter")
-    print("Otherwise, please press any other key")
-    select = input()
-
-    if select == "":
-        print(f"You selected default options.")
-    else:
-        message = "Type 1 or 2 to specify dataset: 1) kitti_raw_test, 2) kitti_odom_test"
-        ds_id = uf.input_integer(message, 1, 2)
-        if ds_id == 1:
-            options["data_dir_name"] = "kitti_raw_test"
-        if ds_id == 2:
-            options["data_dir_name"] = "kitti_odom_test"
-
-        print("Type model_name: dir name under opts.DATAPATH_CKP and opts.DATAPATH_PRD")
-        options["model_name"] = input()
-
-    print("Prediction options:", options)
-    evaluate(**options)
-
-
 def evaluate(data_dir_name, model_name):
     total_depth_pred, total_pose_pred = load_predictions(model_name)
     dataset = TfrecordReader(op.join(opts.DATAPATH_TFR, data_dir_name), batch_size=1).get_dataset()
@@ -62,7 +31,7 @@ def evaluate(data_dir_name, model_name):
         trajectory_errors.append(trj_err)
         rotational_errors.append(rot_err)
 
-        if depth_valid:
+        if "depth_gt" in x:
             depth_true = x["depth_gt"].numpy()[0]
             depth_pred = total_depth_pred[i]
             depth_err = evaluate_depth(depth_pred, depth_true)

--- a/model/model_util/distributer.py
+++ b/model/model_util/distributer.py
@@ -37,8 +37,8 @@ class StrategyDataset:
         if opts.TRAIN_MODE == "distributed":
             print("[StrategyDataset]", self.func.__name__, *args)
             strategy = DistributionStrategy.get_strategy()
-            datset, steps = self.func(*args, **kwargs)
-            dist_dataset = strategy.experimental_distribute_dataset(datset)
+            dataset, steps = self.func(*args, **kwargs)
+            dist_dataset = strategy.experimental_distribute_dataset(dataset)
             return dist_dataset, steps
         else:
             return self.func(*args, **kwargs)

--- a/tfrecords/create_tfrecords_main.py
+++ b/tfrecords/create_tfrecords_main.py
@@ -39,6 +39,8 @@ def tfrecord_maker_factory(dataset, split, srcpath, tfrpath):
         return tm.CityscapesTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
     elif dataset is "waymo":
         return tm.WaymoTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
+    elif dataset is "a2d2":
+        return tm.A2D2TfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
     elif dataset is "driving_stereo":
         return tm.DrivingStereoTfrecordMaker(dataset, split, srcpath, tfrpath, 2000, opts.STEREO, dstshape)
     else:

--- a/tfrecords/readers/a2d2_reader.py
+++ b/tfrecords/readers/a2d2_reader.py
@@ -1,13 +1,17 @@
 import os
-import os.path as op
 import zipfile
 import tarfile
 from PIL import Image
-import cv2
+from glob import glob
+import os.path as op
 import numpy as np
 import json
-from glob import glob
+import cv2
+
+from tfrecords.readers.reader_base import DataReaderBase
+from tfrecords.tfr_util import resize_depth_map
 from utils.util_funcs import print_progress_status
+
 
 # TODO: check staic frame 20180810150607_camera_frontcenter_000007746.png
 
@@ -18,7 +22,7 @@ def convert_tar_to_vanilla_zip():
     tar_files = glob(tar_pattern)
     tar_files = [file for file in tar_files if "frontcenter" not in file]
     for ti, tar_name in enumerate(tar_files):
-        print("====== open tar file:", op.basename(tar_name))
+        print("\n====== open tar file:", op.basename(tar_name))
         tfile = tarfile.open(tar_name, 'r')
         filename = op.basename(tar_name).replace(".tar", ".zip")
         zip_name = op.join(op.dirname(tar_name), "zips", filename)
@@ -44,5 +48,374 @@ def convert_tar_to_vanilla_zip():
         zfile.close()
 
 
+class A2D2Reader(DataReaderBase):
+    def __init__(self, split="", reader_arg=None):
+        super().__init__(split)
+        self.zip_files = reader_arg
+        self.frame_buffer = dict()
+        configfile = op.join(op.dirname(self.zip_files["camera_left"].filename), "cams_lidars.json")
+        print("conf", configfile)
+        self.sensor_config = SensorConfig(configfile)
+        self.latest_index = 0
+
+    """
+    Public methods used outside this class
+    """
+    def init_drive(self, drive_path):
+        """
+        prepare variables to read a new sequence data
+        """
+        self.frame_names = self.zip_files["camera_left"].namelist()
+        self.frame_names = [name for name in self.frame_names if name.endswith(".png")]
+        self.frame_names.sort()
+
+    def num_frames_(self):
+        return len(self.frame_names)
+
+    def get_range_(self):
+        num_frames = self.num_frames_()
+        return range(2, num_frames-2)
+
+    def get_image(self, index, right=False):
+        key = "image_R" if right else "image"
+        return self.get_frame_data(index, key)
+
+    def get_pose(self, index, right=False):
+        key = "pose_gt_R" if right else "pose_gt"
+        return self.get_frame_data(index, key)
+
+    def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
+        key = "depth_gt_R" if right else "depth_gt"
+        depth_map = self.get_frame_data(index, key)
+        srcshape_hw = self.sensor_config.get_resolution_hw("front_left")
+        return resize_depth_map(depth_map, srcshape_hw, dstshape_hw)
+
+    def get_intrinsic(self, index=0, right=False):
+        key = "intrinsic_R" if right else "intrinsic"
+        return self.get_frame_data(index, key)
+
+    def get_stereo_extrinsic(self, index=0):
+        return self.get_frame_data(index, "stereo_T_LR")
+
+    """
+    Private methods used inside this class
+    """
+    def get_frame_data(self, index, key):
+        # use loaded frame
+        if index in self.frame_buffer:
+            return self.frame_buffer[index][key]
+
+        # add new frame
+        frame_data = dict()
+        print("[get_frame_data] 2")
+        frame_data["image"] = self._read_image(index)
+        print("[get_frame_data] 3")
+        frame_data["intrinsic"] = self.sensor_config.get_cam_matrix("front_left")
+        print("[get_frame_data] 4")
+        frame_data["depth_gt"] = self._read_depth_map(index)
+        print("[get_frame_data] 5")
+        frame_data["image_R"] = self._read_image(index, right=True)
+        frame_data["intrinsic_R"] = self.sensor_config.get_cam_matrix("front_right")
+        frame_data["stereo_T_LR"] = self.sensor_config.get_stereo_extrinsic()
+        self.frame_buffer[index] = frame_data
+        print("[get_frame_data] 3")
+
+        # remove old frames
+        if self.latest_index < index:
+            self.latest_index = index
+        indices_pop = []
+        for frame_idx in self.frame_buffer:
+            if frame_idx < self.latest_index - 20:
+                indices_pop.append(frame_idx)
+        print("[get_frame_data] 4")
+        for frame_idx in indices_pop:
+            self.frame_buffer.pop(frame_idx)
+
+        # return requested data
+        return self.frame_buffer[index][key]
+
+    def _read_image(self, index, right=False):
+        """
+        !! NOTE: images are already undistorted, NO need to undistort images
+        """
+        if right:
+            image_name = self.frame_names[index].replace("frontleft", "frontright").replace("front_left", "front_right")
+            zipkey = "camera_right"
+            cam_dir = "front_right"
+        else:
+            image_name = self.frame_names[index]
+            zipkey = "camera_left"
+            cam_dir = "front_left"
+        image_bytes = self.zip_files[zipkey].open(image_name)
+        image = Image.open(image_bytes)
+        image = np.array(image, np.uint8)
+        # image = self.sensor_config.undistort_image(image, cam_dir)
+        return image
+
+    def _read_depth_map(self, index, right=False):
+        image_name = self.frame_names[index]
+        if right:
+            image_name = image_name.replace("frontleft", "frontright").replace("front_left", "front_right")
+        npz_name = image_name.replace("_camera_", "_lidar_").replace("/camera/", "/lidar/").replace(".png", ".npz")
+        lidar_key = "lidar_right" if right else "lidar_left"
+        npzfile = self.zip_files[lidar_key].open(npz_name)
+        npzfile = np.load(npzfile)
+        lidar_row = (npzfile["pcloud_attr.row"] + 0.5).astype(np.int32)
+        lidar_col = (npzfile["pcloud_attr.col"] + 0.5).astype(np.int32)
+        lidar_depth = npzfile["pcloud_attr.depth"]
+        camera_key = "front_right" if right else "front_left"
+        imsize_hw = self.sensor_config.get_resolution_hw(camera_key)
+
+        print("image size:", imsize_hw)
+        assert (lidar_row >= 0).all() and (lidar_row < imsize_hw[0]).all(), \
+            f"wrong index: {lidar_row[lidar_row >= 0]}, {lidar_row[lidar_row < imsize_hw[0]]}"
+        assert (lidar_col >= 0).all() and (lidar_col < imsize_hw[1]).all(), \
+            f"wrong index: {lidar_col[lidar_col >= 0]}, {lidar_col[lidar_col < imsize_hw[1]]}"
+
+        depth_map = np.zeros(imsize_hw, dtype=np.float32)
+        depth_map[lidar_row, lidar_col] = lidar_depth
+        # depth is supposed to have shape [H, W, 1]
+        return depth_map[:, :, np.newaxis]
+
+
+class SensorConfig:
+    # refer to: https://www.a2d2.audi/a2d2/en/tutorial.html
+    def __init__(self, cfgfile):
+        with open(cfgfile, "r") as fr:
+            self.sensor_config = json.load(fr)
+        self.undist_remap = dict()
+
+    def get_cam_matrix(self, cam_key):
+        intrinsic = np.asarray(self.sensor_config["cameras"][cam_key]["CamMatrix"], dtype=np.float32)
+        return intrinsic
+
+    def get_resolution_hw(self, cam_key):
+        resolution = self.sensor_config["cameras"][cam_key]["Resolution"]
+        resolution = np.asarray([resolution[1], resolution[0]], dtype=np.int32)
+        return resolution
+
+    def undistort_image(self, image, cam_name):
+        intr_mat_dist = np.asarray(self.sensor_config['cameras'][cam_name]['CamMatrixOriginal'])
+        intr_mat_undist = np.asarray(self.sensor_config['cameras'][cam_name]['CamMatrix'])
+        dist_parms = np.asarray(self.sensor_config['cameras'][cam_name]['Distortion'])
+        lens = self.sensor_config['cameras'][cam_name]['Lens']
+        if lens == 'Fisheye':
+            return cv2.fisheye.undistortImage(image, intr_mat_dist, D=dist_parms, Knew=intr_mat_undist)
+        elif lens == 'Telecam':
+            return cv2.undistort(image, intr_mat_dist, distCoeffs=dist_parms, newCameraMatrix=intr_mat_undist)
+        else:
+            return image
+
+    def __undistort_image_legacy(self, image, cam_name):
+        """
+        !! NOTE: cv2.remap makes an error when image size is LARGE
+        """
+        map1, map2 = self._get_undistort_remap(cam_name, (image.shape[1], image.shape[0]))
+        print("undistort_image]", image.shape, image.dtype, map1.shape, map1.dtype, map2.shape, map2.dtype)
+        print(map1[0:-1:300, 0:-1:300], "\n", map2[0:-1:300, 0:-1:300])
+        print("remap min max:", np.min(map1), np.max(map1), np.min(map2), np.max(map2))
+        # map1 = np.clip(map1, 0, image.shape[1] - 1)
+        # map2 = np.clip(map2, 0, image.shape[0] - 1)
+        undist_image = cv2.remap(image, map1, map2, interpolation=cv2.INTER_LINEAR)
+        print("undist_image", undist_image.shape, undist_image.dtype)
+        return undist_image
+
+    def _get_undistort_remap(self, cam_name, imsize_wh):
+        if cam_name in self.undist_remap:
+            return self.undist_remap[cam_name]
+
+        # get parameters from config file
+        intr_mat_dist = np.asarray(self.sensor_config['cameras'][cam_name]['CamMatrixOriginal'])
+        intr_mat_undist = np.asarray(self.sensor_config['cameras'][cam_name]['CamMatrix'])
+        dist_parms = np.asarray(self.sensor_config['cameras'][cam_name]['Distortion'])
+        lens = self.sensor_config['cameras'][cam_name]['Lens']
+
+        if lens == 'Fisheye':
+            remapper = cv2.fisheye.initUndistortRectifyMap(K=intr_mat_dist, D=dist_parms, R=np.eye(3, dtype=np.float32),
+                                                           P=intr_mat_undist, size=imsize_wh, m1type=cv2.CV_32FC1)
+        elif lens == 'Telecam':
+            remapper = cv2.initUndistortRectifyMap(intr_mat_dist, distCoeffs=dist_parms, R=np.eye(3, dtype=np.float32),
+                                                   newCameraMatrix=intr_mat_undist, size=imsize_wh, m1type=cv2.CV_32FC1)
+        else:
+            raise ValueError(f"Wrong camera type {lens}")
+
+        self.undist_remap[cam_name] = remapper
+        return remapper
+
+    def get_stereo_extrinsic(self):
+        left_view = self.sensor_config["cameras"]["front_left"]["view"]
+        right_view = self.sensor_config["cameras"]["front_right"]["view"]
+        return self._transform_from_to(right_view, left_view)
+
+    def _transform_from_to(self, source, target):
+        transform = np.dot(np.linalg.inv(self._get_transform_to_global(target)),
+                           self._get_transform_to_global(source))
+        return transform
+
+    def _get_transform_to_global(self, view):
+        # get axes
+        x_axis, y_axis, z_axis = self._get_axes_of_a_view(view)
+        # get origin
+        origin = view['origin']
+        transform_to_global = np.eye(4)
+        # rotation
+        transform_to_global[0:3, 0] = x_axis
+        transform_to_global[0:3, 1] = y_axis
+        transform_to_global[0:3, 2] = z_axis
+        # origin
+        transform_to_global[0:3, 3] = origin
+        return transform_to_global
+
+    def _get_axes_of_a_view(self, view):
+        x_axis = view['x-axis']
+        y_axis = view['y-axis']
+        x_axis_norm = np.linalg.norm(x_axis)
+        y_axis_norm = np.linalg.norm(y_axis)
+        if (x_axis_norm < 1.0e-10) or (y_axis_norm < 1.0e-10):
+            raise ValueError("Norm of input vector(s) too small.")
+        # normalize the axes
+        x_axis = x_axis / x_axis_norm
+        y_axis = y_axis / y_axis_norm
+        # make a new y-axis which lies in the original x-y plane, but is orthogonal to x-axis
+        y_axis = y_axis - x_axis * np.dot(y_axis, x_axis)
+
+        # create orthogonal z-axis
+        z_axis = np.cross(x_axis, y_axis)
+        # calculate and check y-axis and z-axis norms
+        y_axis_norm = np.linalg.norm(y_axis)
+        z_axis_norm = np.linalg.norm(z_axis)
+        if (y_axis_norm < 1.0e-10) or (z_axis_norm < 1.0e-10):
+            raise ValueError("Norm of view axis vector(s) too small.")
+        # make x/y/z-axes orthonormal
+        y_axis = y_axis / y_axis_norm
+        z_axis = z_axis / z_axis_norm
+        return x_axis, y_axis, z_axis
+
+
+# ======================================================================
+from config import opts
+from tfrecords.tfr_util import apply_color_map
+
+
+def test_read_npz():
+    datapath = opts.get_raw_data_path("a2d2")
+    filepath = op.join(datapath, "zips", "camera_lidar-20180810150607_lidar_frontright.zip")
+    zfile = zipfile.ZipFile(filepath, "r")
+    filelist = zfile.namelist()
+    npzfile = zfile.open(filelist[5])
+    # print("npbytes", len(npbytes), npbytes[:100])
+    npzfile = np.load(npzfile)
+    print("npz keys:", list(npzfile.keys()))
+    point_cloud = npzfile["pcloud_points"]
+    print("point_cloud:", point_cloud.shape)
+    lidar_id = npzfile["pcloud_attr.lidar_id"]
+    print("lidar_id", lidar_id.shape, lidar_id[0:-1:1000])
+    lidar_valid = npzfile["pcloud_attr.valid"]
+    print("pcloud_attr.valid", lidar_valid.shape, len(lidar_valid[~lidar_valid]))
+    lidar_row = npzfile["pcloud_attr.row"]
+    print("pcloud_attr.row", lidar_row.shape, np.min(lidar_row), np.max(lidar_row), "\n", lidar_row[0:-1:1000])
+    lidar_col = npzfile["pcloud_attr.col"]
+    print("pcloud_attr.col", lidar_col.shape, np.min(lidar_col), np.max(lidar_col), "\n", lidar_col[0:-1:1000])
+    lidar_depth = npzfile["pcloud_attr.depth"]
+    print("pcloud_attr.depth", lidar_depth.shape, np.min(lidar_depth), np.max(lidar_depth), "\n", lidar_depth[0:-1:1000])
+
+
+def visualize_depth_map():
+    datapath = opts.get_raw_data_path("a2d2")
+    # read lidar file
+    filepath = op.join(datapath, "zips", "camera_lidar-20180810150607_lidar_frontright.zip")
+    zfile_lidar = zipfile.ZipFile(filepath, "r")
+    lidar_list = zfile_lidar.namelist()
+    npzfile = zfile_lidar.open(lidar_list[5])
+    npzfile = np.load(npzfile)
+
+    # read image file
+    filepath = op.join(datapath, "zips", "camera_lidar-20180810150607_camera_frontright.zip")
+    zfile_camera = zipfile.ZipFile(filepath, "r")
+    camera_file = lidar_list[5].replace("_lidar_", "_camera_").replace("/lidar/", "/camera/").replace(".npz", ".png")
+    image_bytes = zfile_camera.open(camera_file)
+    image = Image.open(image_bytes)
+    image = np.array(image, np.uint8)
+    image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+    image_view = cv2.resize(image, (image.shape[1]//2, image.shape[0]//2))
+    image_crop = image[136:-240]
+    image_crop_view = cv2.resize(image_crop, (image_crop.shape[1] // 2, image_crop.shape[0] // 2))
+
+    lidar_row = (npzfile["pcloud_attr.row"] + 0.5).astype(np.int32)
+    lidar_col = (npzfile["pcloud_attr.col"] + 0.5).astype(np.int32)
+    lidar_depth = npzfile["pcloud_attr.depth"]
+    image_shape_hw = (1208, 1920)
+    depth_map = np.zeros(image_shape_hw, dtype=np.float32)
+    depth_map[lidar_row, lidar_col] = lidar_depth
+    depth_color = apply_color_map(depth_map)
+
+    dst_shape_hw = (1208//4, 1920//4)
+    print("dst shape:", dst_shape_hw)
+    rsz_depth_map = resize_depth_map(depth_map, image_shape_hw, dst_shape_hw)
+    rsz_depth_color = apply_color_map(rsz_depth_map)
+
+    image[lidar_row, lidar_col, :] = depth_color[lidar_row, lidar_col, :]
+    # cv2.imshow("depthmap", depth_color)
+    cv2.imshow("depthrsz", rsz_depth_color)
+    cv2.imshow("image", image_view)
+    cv2.imshow("image_crop", image_crop_view)
+    cv2.waitKey()
+
+
+def test_a2d2_reader():
+    datapath = opts.get_raw_data_path("a2d2")
+    imshape_hw = opts.get_img_shape("HW", "a2d2")
+    imshape_wh = opts.get_img_shape("WH", "a2d2")
+    zip_names = {"camera_left": op.join(datapath, "camera_lidar-20180810150607_camera_frontleft.zip"),
+                 "camera_right": op.join(datapath, "camera_lidar-20180810150607_camera_frontright.zip"),
+                 "lidar_left": op.join(datapath, "camera_lidar-20180810150607_lidar_frontleft.zip"),
+                 "lidar_right": op.join(datapath, "camera_lidar-20180810150607_lidar_frontright.zip"),
+                 }
+    zip_files = {key: zipfile.ZipFile(name, "r") for key, name in zip_names.items()}
+    reader = A2D2Reader("train", zip_files)
+    reader.init_drive("")
+    frame_indices = reader.get_range_()
+    for index in frame_indices:
+        image = reader.get_image(index)
+        image_R = reader.get_image(index, right=True)
+        intrinsic = reader.get_intrinsic(index)
+        extrinsic = reader.get_stereo_extrinsic(index)
+        depth = reader.get_depth(index, (0, 0), imshape_hw, intrinsic)
+
+        print("intrinsic:\n", intrinsic)
+        print("extrinsic:\n", extrinsic)
+        image_view = cv2.resize(image, imshape_wh)
+        cv2.imshow("image", image_view)
+        image_R_view = cv2.resize(image_R, imshape_wh)
+        cv2.imshow("image_R", image_R_view)
+        depth_color = apply_color_map(depth)
+        cv2.imshow("depth", depth_color)
+        cv2.waitKey()
+
+
+def test_remap():
+    """
+    cv2.remap function makes error when image size is LARGE
+    """
+    height, width = 2000, 3000
+    map_x, map_y = np.meshgrid(np.arange(0, width, dtype=np.float32), np.arange(0, height, dtype=np.float32))
+    map_x -= 2.5
+    map_y += 3.5
+    image = np.arange(0, map_x.size*3).reshape(height, width, 3).astype(np.uint8)
+    stride = width // 10
+    print("map_x", map_x.dtype, map_x.shape, "\n", map_x[0:-1:stride, 0:-1:stride])
+    print("map_y", map_y.dtype, map_y.shape, "\n", map_y[0:-1:stride, 0:-1:stride])
+    print("image", image.dtype, image.shape, "\n", image[0:-1:stride, 0:-1:stride, 0])
+
+    remapped = cv2.remap(image, map_x, map_y, interpolation=cv2.INTER_NEAREST)
+    print("remapped", remapped.dtype, remapped.shape, "\n", remapped[0:-1:stride, 0:-1:stride, 0])
+
+
 if __name__ == "__main__":
-    convert_tar_to_vanilla_zip()
+    # convert_tar_to_vanilla_zip()
+    # test_read_npz()
+    # visualize_depth_map()
+    test_a2d2_reader()
+    # test_remap()
+
+

--- a/tfrecords/readers/a2d2_reader.py
+++ b/tfrecords/readers/a2d2_reader.py
@@ -1,0 +1,48 @@
+import os
+import os.path as op
+import zipfile
+import tarfile
+from PIL import Image
+import cv2
+import numpy as np
+import json
+from glob import glob
+from utils.util_funcs import print_progress_status
+
+# TODO: check staic frame 20180810150607_camera_frontcenter_000007746.png
+
+
+def convert_tar_to_vanilla_zip():
+    print("\n==== convert_tar_to_vanilla_zip")
+    tar_pattern = "/media/ian/IanBook/datasets/raw_zips/a2d2/*.tar"
+    tar_files = glob(tar_pattern)
+    tar_files = [file for file in tar_files if "frontcenter" not in file]
+    for ti, tar_name in enumerate(tar_files):
+        print("====== open tar file:", op.basename(tar_name))
+        tfile = tarfile.open(tar_name, 'r')
+        filename = op.basename(tar_name).replace(".tar", ".zip")
+        zip_name = op.join(op.dirname(tar_name), "zips", filename)
+        if op.isfile(zip_name):
+            print(f"{op.basename(zip_name)} already made!!")
+            continue
+        os.makedirs(op.dirname(zip_name), exist_ok=True)
+        print("== zip file:", op.basename(zip_name))
+        zfile = zipfile.ZipFile(zip_name, 'w', compression=zipfile.ZIP_STORED)
+
+        for fi, tarinfo in enumerate(tfile):
+            # if fi >= 100:
+            #     break
+            if not tarinfo.isfile():
+                continue
+            inzip_name = tarinfo.name
+            contents = tfile.extractfile(tarinfo)
+            contents = contents.read()
+            zfile.writestr(inzip_name, contents)
+            print_progress_status(f"== converting: tar: {ti}, file: {fi}, {inzip_name[-45:]}")
+
+        tfile.close()
+        zfile.close()
+
+
+if __name__ == "__main__":
+    convert_tar_to_vanilla_zip()

--- a/tfrecords/readers/city_reader.py
+++ b/tfrecords/readers/city_reader.py
@@ -2,9 +2,10 @@ import os.path as op
 import numpy as np
 from PIL import Image
 import json
+from utils.util_class import MyExceptionToCatch
 
 from tfrecords.readers.reader_base import DataReaderBase
-from tfrecords.tfr_util import resize_depth_map, apply_color_map
+from tfrecords.tfr_util import resize_depth_map
 
 
 class CityscapesReader(DataReaderBase):
@@ -107,7 +108,7 @@ class CityscapesReader(DataReaderBase):
         subdrive = "_".join(subdrive)
         subdrive_files = [file for file in self.camera_names if file.startswith(subdrive)]
         if not subdrive_files:
-            raise ValueError(f"No json file like {subdrive}")
+            raise MyExceptionToCatch(f"No json file like {subdrive}")
 
         filename = subdrive_files[0]
         contents = self.zip_files["camera"].read(filename)
@@ -121,6 +122,7 @@ class CityscapesReader(DataReaderBase):
 import cv2
 from config import opts
 import zipfile
+from tfrecords.tfr_util import apply_color_map
 
 
 def test_city_reader():

--- a/tfrecords/readers/driving_reader.py
+++ b/tfrecords/readers/driving_reader.py
@@ -79,7 +79,7 @@ class DrivingStereoReader(DataReaderBase):
         image_bytes = self.zip_files[zipkey].open(filename)
         image = Image.open(image_bytes)
         image = np.array(image, np.uint8)
-        image = image[:, :, [2, 1, 0]]
+        image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
         return image
 
     def get_pose(self, index, right=False):

--- a/tfrecords/readers/kitti_reader.py
+++ b/tfrecords/readers/kitti_reader.py
@@ -51,7 +51,8 @@ class KittiRawReader(DataReaderBase):
             self.cur_images = images
 
         image = np.array(images[1]) if right else np.array(images[0])
-        return image[:, :, [2, 1, 0]]
+        image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+        return image
 
     def get_pose(self, index, right=False):
         T_w_imu = self.drive_loader.oxts[index].T_w_imu
@@ -267,7 +268,8 @@ class KittiOdomReader(DataReaderBase):
             self.cur_images = images
 
         image = np.array(images[1]) if right else np.array(images[0])
-        return image[:, :, [2, 1, 0]]
+        image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+        return image
 
     def get_pose(self, index, right=False):
         if self.split == "train":

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -43,7 +43,7 @@ class WaymoReader(DataReaderBase):
         if right: return None
         frame = self._get_frame(index)
         front_image = tf.image.decode_jpeg(frame.images[0].image)
-        front_image = front_image.numpy()[:, :, [2, 1, 0]]  # rgb to bgr
+        front_image = cv2.cvtColor(front_image.numpy(), cv2.COLOR_RGB2BGR)
         return front_image.astype(np.uint8)
 
     def get_pose(self, index, right=False):
@@ -78,7 +78,7 @@ class WaymoReader(DataReaderBase):
     """
     def _get_dataset(self, drive_path):
         filenames = tf.io.gfile.glob(f"{drive_path}/*.tfrecord")
-        print("[_get_dataset] read tfrecords in", op.basename(drive_path), filenames)
+        print("[WaymoReader._get_dataset] read tfrecords in", op.basename(drive_path), filenames)
         dataset = tf.data.TFRecordDataset(filenames, compression_type='')
         return dataset
 

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -6,6 +6,7 @@ from waymo_open_dataset.utils import frame_utils
 from waymo_open_dataset import dataset_pb2 as open_dataset
 
 from tfrecords.readers.reader_base import DataReaderBase
+from utils.util_class import MyExceptionToCatch
 
 T_C2V = tf.constant([[0, 0, 1, 0], [-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]], dtype=tf.float32)
 FRONT_IND = 0
@@ -86,7 +87,7 @@ class WaymoReader(DataReaderBase):
             frame = self.frame_buffer[index]
             time_of_day = f"{frame.context.stats.time_of_day}"
             if time_of_day != "Day":
-                raise ValueError(f"time_of_day is not Day: {time_of_day}")
+                raise MyExceptionToCatch(f"time_of_day is not Day: {time_of_day}")
             return frame
 
         if (index == self.latest_index + 1) or self.latest_index < 0:
@@ -100,7 +101,7 @@ class WaymoReader(DataReaderBase):
             self.latest_index = index
             time_of_day = f"{frame.context.stats.time_of_day}"
             if time_of_day != "Day":
-                raise ValueError(f"time_of_day is not Day: {time_of_day}")
+                raise MyExceptionToCatch(f"time_of_day is not Day: {time_of_day}")
             # remove an old frame
             return frame
 

--- a/tfrecords/tfr_util.py
+++ b/tfrecords/tfr_util.py
@@ -76,6 +76,8 @@ def read_data_config(value):
 
 
 def resize_depth_map(depth_map, srcshape_hw, dstshape_hw):
+    if depth_map.ndim == 3:
+        depth_map = depth_map[:, :, 0]
     # depth_view = apply_color_map(depth_map)
     # depth_view = cv2.resize(depth_view, (dstshape_hw[1], dstshape_hw[0]))
     # cv2.imshow("srcdepth", depth_view)
@@ -89,10 +91,10 @@ def resize_depth_map(depth_map, srcshape_hw, dstshape_hw):
 
     dst_depth = np.zeros(du.shape).astype(np.float32)
     weight = np.zeros(du.shape).astype(np.float32)
-    for dy in range(-radi_y, radi_y+1):
-        for dx in range(-radi_x, radi_x+1):
-            v_inds = np.clip(sv + dy, 0, srcshape_hw[0] - 1).astype(np.uint16)
-            u_inds = np.clip(su + dx, 0, srcshape_hw[1] - 1).astype(np.uint16)
+    for sdy in range(-radi_y, radi_y+1):
+        for sdx in range(-radi_x, radi_x+1):
+            v_inds = np.clip(sv + sdy, 0, srcshape_hw[0] - 1).astype(np.uint16)
+            u_inds = np.clip(su + sdx, 0, srcshape_hw[1] - 1).astype(np.uint16)
 
             # if (dx==1) and (dy==1):
             #     print("u_inds", u_inds[0:400:20])
@@ -108,9 +110,11 @@ def resize_depth_map(depth_map, srcshape_hw, dstshape_hw):
 
 
 def apply_color_map(depth):
-    depth = depth[:, :, 0]
+    if len(depth.shape) > 2:
+        depth = depth[:, :, 0]
     depth_view = (np.clip(depth, 0, 50.) / 50. * 255).astype(np.uint8)
     depth_view = cv2.applyColorMap(depth_view, cv2.COLORMAP_SUMMER)
+    depth_view[depth == 0, :] = (0, 0, 0)
     return depth_view
 
 

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -10,6 +10,7 @@ import utils.util_funcs as uf
 import utils.util_class as uc
 from tfrecords.example_maker import ExampleMaker
 from tfrecords.tfr_util import Serializer, inspect_properties
+from utils.util_class import MyExceptionToCatch
 
 
 class TfrecordMakerBase:
@@ -74,8 +75,8 @@ class TfrecordMakerBase:
                     except StopIteration as si: # raised from xxx_reader._get_frame()
                         print("\n[StopIteration] stop this drive", si)
                         break
-                    except ValueError as ve:    # raised from xxx_reader._get_frame()
-                        uf.print_progress_status(f"==[making TFR] ValueError frame: {ii}/{num_frames}, {ve}")
+                    except MyExceptionToCatch as ve:    # raised from xxx_reader._get_frame()
+                        uf.print_progress_status(f"==[making TFR] (Exception) frame: {ii}/{num_frames}, {ve}")
                         continue
 
                     if not example:             # when dict is empty, skip this index

--- a/utils/util_class.py
+++ b/utils/util_class.py
@@ -37,6 +37,7 @@ class PathManager:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.closer:
             self.closer()
+
         if self.safe_exit is False:
             print("[PathManager] the process is NOT ended properly, remove the working paths")
             for path in self.paths:

--- a/utils/util_class.py
+++ b/utils/util_class.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 
-class TrainException(Exception):
+class MyExceptionToCatch(Exception):
     def __init__(self, msg):
         super().__init__(msg)
 


### PR DESCRIPTION

## example_maker.py

### resize 비율 유지

이미지를 resize할 때 가로 세로 비율을 유지하도록 resize 크기를 조절
resize shape과 tfrecord shape이 다를 수 있음
예를들어 원본 이미지가 (1000, 2000)이고 만들고자하는 tfrecord shape이 (100, 400)이면
이미지를 일단 (200, 400)으로 resize

### crop

resize shape과 tfrecord shape이 다른 경우 resized image에서 남는 부분을 crop
위 예시라면 (200, 400) 이미지에서 위 아래 50씩 잘라내고 (100, 400)을 tfrecord로 저장

## tfrecord_maker.py

A2D2TfrecordMaker 구현
zip 파일 한 세트를 drive 단위로 사용

## a2d2_reader.py

### convert_tar_to_vanilla_zip

A2D2 데이터셋은 원래 tar로 압축되어 있는데 tar는 파일 리스트를 만드는데 오래걸려서 
tar를 zip으로 변환해주는 함수 구현
zip은 압축하지 않아서 읽고 보는게 빠름

### A2D2Reader

A2D2 데이터셋을 읽어주는 reader 클래스 구현
drive 하나당 4개의 zip이 있어서 4개의 zipfile.ZipFile로 파일 열기 
=> (camera_left, camera_right, lidar_left, lidar_right)
