### PR TITLE
Predict and evaluate

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -28,7 +28,7 @@ class FixedOptions:
                    "cityscapes": (192, 384),
                    "waymo": (256, 384),
                    "a2d2": (256, 512),
-                   # "driving_stereo": (192, 384),
+                   "driving_stereo": (192, 384),
                    }
     IMAGE_CROP = {"kitti_raw": True,
                   "kitti_odom": True,
@@ -37,7 +37,7 @@ class FixedOptions:
     """
     training options
     """
-    PER_REPLICA_BATCH = 4
+    PER_REPLICA_BATCH = 2
     BATCH_SIZE = PER_REPLICA_BATCH
     OPTIMIZER = ["adam_constant"][0]
     DEPTH_ACTIVATION = ["InverseSigmoid", "Exponential"][0]
@@ -96,7 +96,7 @@ class VodeOptions(FixedOptions):
     """
     training options
     """
-    CKPT_NAME = "vode1"
+    CKPT_NAME = "vode2"
     ENABLE_SHAPE_DECOR = False
     LOG_LOSS = True
     TRAIN_MODE = ["eager", "graph", "distributed"][1]
@@ -123,17 +123,23 @@ class VodeOptions(FixedOptions):
     }
     TRAINING_PLAN = [
         # pretraining first round
-        ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T2),
+        ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T1),
         ("kitti_odom",      2, 0.0001, LOSS_WEIGHTS_T1),
+        ("a2d2",            2, 0.0001, LOSS_WEIGHTS_T1),
         ("waymo",           2, 0.0001, LOSS_WEIGHTS_T1),
         ("cityscapes",      2, 0.0001, LOSS_WEIGHTS_T1),
         # pretraining second round
         ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T1),
         ("kitti_odom",      2, 0.0001, LOSS_WEIGHTS_T1),
+        ("a2d2",            2, 0.0001, LOSS_WEIGHTS_T1),
         ("waymo",           2, 0.0001, LOSS_WEIGHTS_T1),
         ("cityscapes",      2, 0.0001, LOSS_WEIGHTS_T1),
         # fine tuning
         ("kitti_raw",       10, 0.0001, LOSS_WEIGHTS_T1),
+    ]
+    TEST_PLAN = [
+        ("kitti_raw",       ["depth"]),
+        ("kitti_odom",      ["pose"]),
     ]
 
     @classmethod
@@ -171,7 +177,7 @@ class VodeOptions(FixedOptions):
 
 
 opts = VodeOptions()
-
+print("ckpt path", opts.DATAPATH_CKP)
 
 import numpy as np
 np.set_printoptions(precision=4, suppress=True, linewidth=100)

--- a/config-example.py
+++ b/config-example.py
@@ -7,7 +7,8 @@ RAW_DATA_PATHS = {
     "cityscapes__extra": "/media/ian/IanBook/datasets/raw_zips/cityscapes",
     "cityscapes__sequence": "/media/ian/IanBook/datasets/raw_zips/cityscapes",
     "waymo": "/media/ian/IanBook/datasets/waymo",
-    "driving_stereo": "/media/ian/IanBook/datasets/raw_zips/driving_stereo",
+    "a2d2": "/media/ian/IanBook/datasets/raw_zips/a2d2/zips",
+    # "driving_stereo": "/media/ian/IanBook/datasets/raw_zips/driving_stereo",
 }
 # RESULT_DATAPATH = "/home/ian/workspace/vode/vode-data"
 RESULT_DATAPATH = "/media/ian/IanBook/vode_data/vode_stereo_0815"
@@ -26,7 +27,8 @@ class FixedOptions:
                    "kitti_odom": (128, 512),
                    "cityscapes": (192, 384),
                    "waymo": (256, 384),
-                   "driving_stereo": (192, 384),
+                   "a2d2": (256, 512),
+                   # "driving_stereo": (192, 384),
                    }
     IMAGE_CROP = {"kitti_raw": True,
                   "kitti_odom": True,
@@ -44,7 +46,7 @@ class FixedOptions:
     """
     network options: network architecture, convolution args, ... 
     """
-    NET_NAMES = {"depth": "NASNetMobile",
+    NET_NAMES = {"depth": ["MobileNetV2", "NASNetMobile", "DenseNet121", "VGG16", "Xception", "ResNet50V2", "NASNetLarge"][1],
                  "camera": "PoseNet",
                  "flow": "PWCNet"
                  }
@@ -64,6 +66,7 @@ class VodeOptions(FixedOptions):
     # cityscapes__sequence MUST be after cityscapes__extra
     DATASETS_TO_PREPARE = {"kitti_raw": ["train", "test"],
                            "kitti_odom": ["train", "test"],
+                           "a2d2": ["train"],
                            "cityscapes__extra": ["train"],
                            "cityscapes__sequence": ["train"],
                            "waymo": ["train"],

--- a/evaluate/eval_funcs.py
+++ b/evaluate/eval_funcs.py
@@ -29,7 +29,7 @@ def recover_pred_snippet_poses(poses):
     :param poses: source poses that transforms points in target to source frame
                     format=(tx, ty, tz, ux, uy, uz) shape=[numsrc, 6]
     :return: snippet pose matrices that transforms points in source[i] frame to source[0] frame
-                    format=(4x4 transformation) shape=[snippet_len, 4, 4]
+                    format=(4x4 transformation) shape=[snippet, 4, 4]
                     order=[source[0], source[1], target, source[2], source[3]]
     """
     # insert origin pose as target pose into the middle
@@ -74,9 +74,9 @@ def relative_pose_from_first(poses_mat):
 
 def calc_trajectory_error(pose_pred_mat, pose_true_mat):
     """
-    :param pose_pred_mat: predicted snippet pose matrices w.r.t the first frame, [numsrc, 5, 4, 4]
-    :param pose_true_mat: ground truth snippet pose matrices w.r.t the first frame, [numsrc, 5, 4, 4]
-    :return: trajectory error in meter [numsrc]
+    :param pose_pred_mat: predicted snippet pose matrices w.r.t the first frame, [snippet, 5, 4, 4]
+    :param pose_true_mat: ground truth snippet pose matrices w.r.t the first frame, [snippet, 5, 4, 4]
+    :return: trajectory error in meter [snippet]
     """
     xyz_pred = pose_pred_mat[:, :3, 3]
     xyz_true = pose_true_mat[:, :3, 3]
@@ -89,9 +89,9 @@ def calc_trajectory_error(pose_pred_mat, pose_true_mat):
 
 def calc_rotational_error(pose_pred_mat, pose_true_mat):
     """
-    :param pose_pred_mat: predicted snippet pose matrices w.r.t the first frame, [snippet_len, 5, 4, 4]
-    :param pose_true_mat: ground truth snippet pose matrices w.r.t the first frame, [snippet_len, 5, 4, 4]
-    :return: rotational error in rad [snippet_len]
+    :param pose_pred_mat: predicted snippet pose matrices w.r.t the first frame, [snippet, 5, 4, 4]
+    :param pose_true_mat: ground truth snippet pose matrices w.r.t the first frame, [snippet, 5, 4, 4]
+    :return: rotational error in rad [snippet]
     """
     rot_pred = pose_pred_mat[:, :3, :3]
     rot_true = pose_true_mat[:, :3, :3]

--- a/evaluate/eval_funcs.py
+++ b/evaluate/eval_funcs.py
@@ -32,6 +32,7 @@ def recover_pred_snippet_poses(poses):
                     format=(4x4 transformation) shape=[snippet_len, 4, 4]
                     order=[source[0], source[1], target, source[2], source[3]]
     """
+    # insert origin pose as target pose into the middle
     target_pose = np.zeros(shape=(1, 6), dtype=np.float32)
     poses_vec = np.concatenate([poses[:2], target_pose, poses[2:]], axis=0)
     poses_mat = cp.pose_rvec2matr(poses_vec)
@@ -73,9 +74,9 @@ def relative_pose_from_first(poses_mat):
 
 def calc_trajectory_error(pose_pred_mat, pose_true_mat):
     """
-    :param pose_pred_mat: predicted snippet pose matrices w.r.t the first frame, [snippet_len, 5, 4, 4]
-    :param pose_true_mat: ground truth snippet pose matrices w.r.t the first frame, [snippet_len, 5, 4, 4]
-    :return: trajectory error in meter [snippet_len]
+    :param pose_pred_mat: predicted snippet pose matrices w.r.t the first frame, [numsrc, 5, 4, 4]
+    :param pose_true_mat: ground truth snippet pose matrices w.r.t the first frame, [numsrc, 5, 4, 4]
+    :return: trajectory error in meter [numsrc]
     """
     xyz_pred = pose_pred_mat[:, :3, 3]
     xyz_true = pose_true_mat[:, :3, 3]

--- a/model/build_model/pose_net.py
+++ b/model/build_model/pose_net.py
@@ -9,7 +9,7 @@ class PoseNet:
         self.input_shape = input_shape
         self.global_batch = global_batch
         self.conv2d_p = conv2d
-        print("[PoseNet] convolution default options:", input_shape, vars(conv2d))
+        print("[PoseNet] convolution default options:", vars(conv2d))
 
     def __call__(self):
         batch, snippet, height, width, channel = self.input_shape

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -32,10 +32,10 @@ class ExampleMaker:
             return CityscapesReader(self.split, self.reader_args)   # split and ZipFile object
         elif self.dataset == "waymo":
             return WaymoReader(self.split)
-        elif self.dataset == "driving_stereo":
-            return DrivingStereoReader(self.split)
         elif self.dataset == "a2d2":
             return A2D2Reader(self.split, self.reader_args)
+        elif self.dataset == "driving_stereo":
+            return DrivingStereoReader(self.split)
         else:
             assert 0, f"[data_reader_factory] invalid dataset name {self.dataset}"
 

--- a/tfrecords/readers/a2d2_reader.py
+++ b/tfrecords/readers/a2d2_reader.py
@@ -17,9 +17,12 @@ from utils.util_funcs import print_progress_status
 
 
 def convert_tar_to_vanilla_zip():
+    from config import opts
+
     print("\n==== convert_tar_to_vanilla_zip")
-    tar_pattern = "/media/ian/IanBook/datasets/raw_zips/a2d2/*.tar"
+    tar_pattern = opts.get_raw_data_path("a2d2") + "/../*.tar"
     tar_files = glob(tar_pattern)
+    print("tar files:", tar_pattern, tar_files)
     tar_files = [file for file in tar_files if "frontcenter" not in file]
     for ti, tar_name in enumerate(tar_files):
         print("\n====== open tar file:", op.basename(tar_name))
@@ -298,7 +301,6 @@ class SensorConfig:
 
 
 # ======================================================================
-from config import opts
 from tfrecords.tfr_util import apply_color_map
 
 


### PR DESCRIPTION

## model_main.py

config에 `TEST_PLAN`에 따라 predict_by_plan() 이 여러 데이터셋에 대해 predict()를 실행
predict()에서는 save_key의 데이터를 prediction과 gt 데이터를 묶어서 npz로 저장
예를 들면 kitti_odom에서는 {"pose": pose_pred, "pose_gt": pose_true} 이런 데이터를 
하나의 npz에 저장: `{dataset_name}.npz`

## model_wrapper.py

predict_dataset()에서 prediction을 전부 저장하는 것이 아니라 
save_keys 입력 인자로 각 데이터셋마다 evaluate 할 데이터만 골라 저장
출력에 prediction 뿐만 아니라 그에 해당하는 gt 데이터도 묶어서 출력

# evaluate_main.py

config에 `TEST_PLAN`에 따라 evaluate_by_plan() 이 여러 데이터셋에 대해 evaluate()을 실행
기존에는 gt 데이터를 tfrecord에서 불러왔지만 이제는 prediction 과정에서 
gt를 같이 저장하기 때문에 npz 파일만 부르면 됨
샘플 별 error 계산해서 txt 파일로 저장
