### PR TITLE
Flownet only training

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -96,7 +96,7 @@ class VodeOptions(FixedOptions):
     """
     training options
     """
-    CKPT_NAME = "vode2"
+    CKPT_NAME = "vode3"
     ENABLE_SHAPE_DECOR = False
     LOG_LOSS = True
     TRAIN_MODE = ["eager", "graph", "distributed"][1]
@@ -121,6 +121,11 @@ class VodeOptions(FixedOptions):
         "flowL2": 1., "flowL2_R": 1.,
         "flow_reg": 4e-7
     }
+    LOSS_WEIGHTS_FLOW = {
+        "flowL2": 1., "flowL2_R": 1.,
+        "flow_reg": 4e-7
+    }
+
     TRAINING_PLAN = [
         # pretraining first round
         ("kitti_raw",       2, 0.0001, LOSS_WEIGHTS_T1),
@@ -136,6 +141,14 @@ class VodeOptions(FixedOptions):
         ("cityscapes",      2, 0.0001, LOSS_WEIGHTS_T1),
         # fine tuning
         ("kitti_raw",       10, 0.0001, LOSS_WEIGHTS_T1),
+    ]
+    TRAINING_FLOW_PLAN = [
+        # pretraining first round
+        ("kitti_raw",       5, 0.0001, LOSS_WEIGHTS_FLOW),
+        ("kitti_odom",      5, 0.0001, LOSS_WEIGHTS_FLOW),
+        ("a2d2",            5, 0.0001, LOSS_WEIGHTS_FLOW),
+        ("waymo",           5, 0.0001, LOSS_WEIGHTS_FLOW),
+        ("cityscapes",      5, 0.0001, LOSS_WEIGHTS_FLOW),
     ]
     TEST_PLAN = [
         ("kitti_raw",       ["depth"]),

--- a/model/build_model/flow_net.py
+++ b/model/build_model/flow_net.py
@@ -1,9 +1,10 @@
 import tensorflow as tf
 import tensorflow_addons as tfa
 from tensorflow.keras import layers
-from model.synthesize.bilinear_interp import FlowBilinearInterpolation
 
+from model.synthesize.bilinear_interp import FlowBilinearInterpolation
 import settings
+# Ref: https://github.com/NVlabs/PWC-Net/blob/master/PyTorch/models/PWCNet.py
 
 
 class PWCNet:

--- a/model/build_model/model_factory.py
+++ b/model/build_model/model_factory.py
@@ -24,7 +24,8 @@ class ModelFactory:
         self.global_batch = global_batch
         self.dataset_cfg = dataset_cfg
         self.bshwc_shape = [global_batch] + dataset_cfg["imshape"]
-        self.net_names = net_names
+        self.net_names = opts.NET_NAMES if net_names is None else net_names
+        print("[ModelFactory] net names:", self.net_names)
         self.activation = depth_activation
         self.pretrained_weight = pretrained_weight
         self.stereo = stereo
@@ -50,7 +51,7 @@ class ModelFactory:
             flownet = self.flow_net_factory(self.net_names["flow"], conv_flow)
             models["flownet"] = flownet
 
-        if "stereo_T_LR" in self.dataset_cfg:
+        if ("stereo_T_LR" in self.dataset_cfg) and ("depth" in self.net_names):
             model_wrapper = mw.StereoPoseModelWrapper(models)
         elif ("image_R" in self.dataset_cfg) and self.stereo:
             model_wrapper = mw.StereoModelWrapper(models)

--- a/model/build_model/model_wrappers.py
+++ b/model/build_model/model_wrappers.py
@@ -122,7 +122,7 @@ class StereoModelWrapper(ModelWrapper):
         predictions = self.predict_batch(features)
         preds_right = self.predict_batch(features, "_R")
         predictions.update(preds_right)
-        return
+        return predictions
 
 
 class StereoPoseModelWrapper(StereoModelWrapper):


### PR DESCRIPTION
여러 모델을 한번에 학습하다보니 메모리 에러가 자주 발생함
flownet은 따로 학습해도 되는 모델이므로 따로 학습하여 메모리 부담을 줄임
flownet 단독 학습을 하기위해
- config.py : `TRAINING_PLAN`과 유사한 `TRAINING_FLOW_PLAN`을 따로 만듦
- model_main.py : `train_flow_by_plan()` 함수에서 flownet만 따로 학습
- loss.py, logger.py, train_val.py : 원래 항상 있던 depth, pose prediction이 없어도 돌아가도록 수정함
