### PR TITLE
Exclude cityscapes extra

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -25,7 +25,7 @@ class FixedOptions:
 
     IMAGE_SIZES = {"kitti_raw": (128, 512),
                    "kitti_odom": (128, 512),
-                   "cityscapes": (192, 384),
+                   "cityscapes": (192, 448),
                    "waymo": (256, 384),
                    "a2d2": (256, 512),
                    "driving_stereo": (192, 384),

--- a/config-example.py
+++ b/config-example.py
@@ -4,11 +4,9 @@ import os.path as op
 RAW_DATA_PATHS = {
     "kitti_raw": "/media/ian/IanBook2/datasets/kitti_raw_data",
     "kitti_odom": "/media/ian/IanBook2/datasets/kitti_odometry",
-    "cityscapes__extra": "/media/ian/IanBook2/datasets/raw_zips/cityscapes",
     "cityscapes__sequence": "/media/ian/IanBook2/datasets/raw_zips/cityscapes",
     "waymo": "/media/ian/IanBook2/datasets/waymo",
     "a2d2": "/media/ian/IanBook2/datasets/raw_zips/a2d2/zips",
-    # "driving_stereo": "/media/ian/IanBook2/datasets/raw_zips/driving_stereo",
 }
 RESULT_DATAPATH = "/media/ian/IanBook2/vode_data/vode_test_1113"
 
@@ -76,14 +74,11 @@ class VodeOptions(FixedOptions):
     """
     data options
     """
-    # cityscapes__sequence MUST be after cityscapes__extra
     DATASETS_TO_PREPARE = {"kitti_raw": ["train", "test"],
                            "kitti_odom": ["train", "test"],
                            "a2d2": ["train"],
-                           # "cityscapes__extra": ["train"],
                            "cityscapes__sequence": ["train"],
                            "waymo": ["train"],
-                           # "driving_stereo": ["train", "test"],
                            }
     # only when making small tfrecords to test training
     FRAME_PER_DRIVE = 0

--- a/config-example.py
+++ b/config-example.py
@@ -2,16 +2,15 @@ import os.path as op
 
 # TODO: add or change RAW_DATA_PATHS as dataset paths in your PC
 RAW_DATA_PATHS = {
-    "kitti_raw": "/media/ian/IanBook/datasets/kitti_raw_data",
-    "kitti_odom": "/media/ian/IanBook/datasets/kitti_odometry",
-    "cityscapes__extra": "/media/ian/IanBook/datasets/raw_zips/cityscapes",
-    "cityscapes__sequence": "/media/ian/IanBook/datasets/raw_zips/cityscapes",
-    "waymo": "/media/ian/IanBook/datasets/waymo",
-    "a2d2": "/media/ian/IanBook/datasets/raw_zips/a2d2/zips",
-    # "driving_stereo": "/media/ian/IanBook/datasets/raw_zips/driving_stereo",
+    "kitti_raw": "/media/ian/IanBook2/datasets/kitti_raw_data",
+    "kitti_odom": "/media/ian/IanBook2/datasets/kitti_odometry",
+    "cityscapes__extra": "/media/ian/IanBook2/datasets/raw_zips/cityscapes",
+    "cityscapes__sequence": "/media/ian/IanBook2/datasets/raw_zips/cityscapes",
+    "waymo": "/media/ian/IanBook2/datasets/waymo",
+    "a2d2": "/media/ian/IanBook2/datasets/raw_zips/a2d2/zips",
+    # "driving_stereo": "/media/ian/IanBook2/datasets/raw_zips/driving_stereo",
 }
-# RESULT_DATAPATH = "/home/ian/workspace/vode/vode-data"
-RESULT_DATAPATH = "/media/ian/IanBook/vode_data/vode_stereo_0815"
+RESULT_DATAPATH = "/media/ian/IanBook2/vode_data/vode_test_1113"
 
 
 class FixedOptions:
@@ -61,32 +60,13 @@ class FixedOptions:
 
 class VodeOptions(FixedOptions):
     """
-    data options
-    """
-    # cityscapes__sequence MUST be after cityscapes__extra
-    DATASETS_TO_PREPARE = {"kitti_raw": ["train", "test"],
-                           "kitti_odom": ["train", "test"],
-                           "a2d2": ["train"],
-                           "cityscapes__extra": ["train"],
-                           "cityscapes__sequence": ["train"],
-                           "waymo": ["train"],
-                           # "driving_stereo": ["train", "test"],
-                           }
-    # only when making small tfrecords to test training
-    FRAME_PER_DRIVE = 100
-    TOTAL_FRAME_LIMIT = 500
-    VALIDATION_FRAMES = 300
-    AUGMENT_PROBS = {"CropAndResize": 0.2,
-                     "HorizontalFlip": 0.2,
-                     "ColorJitter": 0.2}
-
-    """
     path options
     """
+    CKPT_NAME = "vode_flow2"
     DATAPATH = RESULT_DATAPATH
     assert(op.isdir(DATAPATH))
     DATAPATH_SRC = op.join(DATAPATH, "srcdata")
-    DATAPATH_TFR = op.join(DATAPATH, "tfrecords_small")
+    DATAPATH_TFR = op.join(DATAPATH, "tfrecords")
     DATAPATH_CKP = op.join(DATAPATH, "checkpts")
     DATAPATH_LOG = op.join(DATAPATH, "log")
     DATAPATH_PRD = op.join(DATAPATH, "prediction")
@@ -94,9 +74,28 @@ class VodeOptions(FixedOptions):
     PROJECT_ROOT = op.dirname(__file__)
 
     """
+    data options
+    """
+    # cityscapes__sequence MUST be after cityscapes__extra
+    DATASETS_TO_PREPARE = {"kitti_raw": ["train", "test"],
+                           "kitti_odom": ["train", "test"],
+                           "a2d2": ["train"],
+                           # "cityscapes__extra": ["train"],
+                           "cityscapes__sequence": ["train"],
+                           "waymo": ["train"],
+                           # "driving_stereo": ["train", "test"],
+                           }
+    # only when making small tfrecords to test training
+    FRAME_PER_DRIVE = 0
+    TOTAL_FRAME_LIMIT = 0
+    VALIDATION_FRAMES = 300
+    AUGMENT_PROBS = {"CropAndResize": 0.2,
+                     "HorizontalFlip": 0.2,
+                     "ColorJitter": 0.2}
+
+    """
     training options
     """
-    CKPT_NAME = "vode3"
     ENABLE_SHAPE_DECOR = False
     LOG_LOSS = True
     TRAIN_MODE = ["eager", "graph", "distributed"][1]
@@ -149,6 +148,12 @@ class VodeOptions(FixedOptions):
         ("a2d2",            5, 0.0001, LOSS_WEIGHTS_FLOW),
         ("waymo",           5, 0.0001, LOSS_WEIGHTS_FLOW),
         ("cityscapes",      5, 0.0001, LOSS_WEIGHTS_FLOW),
+        # pretraining second round
+        ("kitti_raw",       3, 0.00001, LOSS_WEIGHTS_FLOW),
+        ("kitti_odom",      3, 0.00001, LOSS_WEIGHTS_FLOW),
+        ("a2d2",            3, 0.00001, LOSS_WEIGHTS_FLOW),
+        ("waymo",           3, 0.00001, LOSS_WEIGHTS_FLOW),
+        ("cityscapes",      3, 0.00001, LOSS_WEIGHTS_FLOW),
     ]
     TEST_PLAN = [
         ("kitti_raw",       ["depth"]),

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -41,8 +41,8 @@ def save_results(epoch, dataset_name, results_train, results_val, columns, filen
     저장된 csv 파일에서 하나의 column 너비는 가급적 6 글자가 되도록 맞춘다.
     예시:
         epoch,dataset,:loss ,:TE   ,:RE   ,  |   ,!loss ,!TE   ,!RE
-        0    ,kitti_r,1.9476,1.3867,0.0130,  |   ,1.1700,0.2056,0.0065
-        1    ,kitti_r,1.8911,1.3442,0.0129,  |   ,1.1845,0.2120,0.0051
+            0,kitti_r,1.9476,1.3867,0.0130,  |   ,1.1700,0.2056,0.0065
+            1,kitti_r,1.8911,1.3442,0.0129,  |   ,1.1845,0.2120,0.0051
 
     - column 이름에서 ':'는 training 결과를 말하고 '!'는 validation 결과를 뜻한다.
     - 6글자에 맞추기 위해 단어들을 줄여서 썼는데 약자들은 상단의 RENAMER나
@@ -82,7 +82,10 @@ def save_results(epoch, dataset_name, results_train, results_val, columns, filen
         val_cols = [col for col in list(results) if col.startswith(VALID_PREFIX)]
         columns = ["epoch", "dataset"] + train_cols + [seperator] + val_cols
         results = results.loc[:, columns]
+        # reorder rows
+        results["epoch"] = results["epoch"].map(lambda x: int(x))
         results = results.sort_values(by=['epoch'])
+        results["epoch"] = results["epoch"].map(lambda x: f"{x:>5}")
     else:
         results = pd.DataFrame([epoch_result])
 

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -52,13 +52,15 @@ def save_results(epoch, dataset_name, results_train, results_val, columns, filen
     train_result = results_train.mean(axis=0).to_dict()
     val_result = results_val.mean(axis=0).to_dict()
 
-    epoch_result = {"epoch": f"{epoch:<5}", "dataset": f"{dataset_name[:7]:<7}"}
+    epoch_result = {"epoch": f"{epoch:>5}", "dataset": f"{dataset_name[:7]:<7}"}
     for colname in columns:
-        epoch_result[TRAIN_PREFIX + colname] = train_result[colname]
+        if colname in train_result:
+            epoch_result[TRAIN_PREFIX + colname] = train_result[colname]
     seperator = "  |   "
     epoch_result[seperator] = seperator
     for colname in columns:
-        epoch_result[VALID_PREFIX + colname] = val_result[colname]
+        if colname in val_result:
+            epoch_result[VALID_PREFIX + colname] = val_result[colname]
     epoch_result = to_fixed_width_column(epoch_result)
 
     # save "how-to-read-columns.json"
@@ -116,12 +118,13 @@ def draw_and_save_plot(results, filename):
     fig, axes = plt.subplots(3, 1)
     fig.set_size_inches(7, 7)
     for i, ax, colname, title in zip(range(3), axes, ['loss ', 'TE   ', 'RE   '], ['Loss', 'Trajectory Error', 'Rotation Error']):
-        ax.plot(results['epoch'].astype(int), results[TRAIN_PREFIX + colname], label='train_' + colname)
-        ax.plot(results['epoch'].astype(int), results[VALID_PREFIX + colname], label='val_' + colname)
-        ax.set_xlabel('epoch')
-        ax.set_ylabel(colname)
-        ax.set_title(title)
-        ax.legend()
+        if TRAIN_PREFIX + colname in results:
+            ax.plot(results['epoch'].astype(int), results[TRAIN_PREFIX + colname], label='train_' + colname)
+            ax.plot(results['epoch'].astype(int), results[VALID_PREFIX + colname], label='val_' + colname)
+            ax.set_xlabel('epoch')
+            ax.set_ylabel(colname)
+            ax.set_title(title)
+            ax.legend()
     fig.tight_layout()
     # save graph as a file
     filepath = op.join(opts.DATAPATH_CKP, opts.CKPT_NAME, filename)

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -7,6 +7,7 @@ from tfrecords.readers.waymo_reader import WaymoReader
 from tfrecords.readers.driving_reader import DrivingStereoReader
 from tfrecords.readers.a2d2_reader import A2D2Reader
 from tfrecords.tfr_util import show_example
+from utils.util_class import MyExceptionToCatch
 
 
 class ExampleMaker:
@@ -187,12 +188,14 @@ class ExampleMaker:
 
             min_dist = np.min(distances)
             if min_dist < 0.2:
-                return dict()   # empty dict means skip this frame
+                raise MyExceptionToCatch("[verify_snippet] poses is not moving")
 
             max_dist = np.max(distances)
             if max_dist > 10.:
                 print("\n  Change scene? distance=", max_dist)
-                return dict()   # empty dict means skip this frame
+                raise MyExceptionToCatch("[verify_snippet] scene is changing")
+
+        example = {key: val for key, val in example.items() if val is not None}
         return example
 
     def crop_example(self, example, rszshape_hw):

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -404,6 +404,7 @@ def move_tfrecord_and_merge_configs(tfrpath__, tfrpath):
             config = json.load(fp)
             total_length += config["length"]
     config["length"] = total_length
+    print("[wrap_up] final config:", config)
     with open(op.join(tfrpath__, "tfr_config.txt"), "w") as fr:
         json.dump(config, fr)
 

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -73,23 +73,19 @@ class TfrecordMakerBase:
 
                     try:
                         example = self.example_maker.get_example(index)
+                        first_example = self.verify_example(first_example, example)
                     except StopIteration as si:         # raised from xxx_reader._get_frame()
                         print("\n[StopIteration] stop this drive", si)
                         break
                     except MyExceptionToCatch as ve:    # raised from xxx_reader._get_frame()
-                        uf.print_progress_status(f"==[making TFR] (Exception) frame: {ii}/{num_frames}, {ve}")
+                        uf.print_progress_status(f"==[making TFR] Exception frame: {ii}/{num_frames}, {ve}")
                         continue
 
-                    if 'image' not in example:             # when dict is empty, skip this index
-                        uf.print_progress_status(f"==[making TFR] INVALID example, frame: {ii}/{num_frames}")
-                        continue
-
-                    first_example = self.check_example_keys(first_example, example)
                     example_serial = self.serialize_example(example)
                     self.write_tfrecord(example_serial, di)
-                    uf.print_progress_status(f"==[making TFR] drive: {di}/{num_drives} | "
-                                             f"drive: {ii}/{num_frames}, count: {self.example_count_in_drive} | "
-                                             f"total: {self.total_example_count} | "
+                    uf.print_progress_status(f"==[making TFR] drives: {di}/{num_drives} | "
+                                             f"index,count: {ii}/{self.example_count_in_drive}/{num_frames} | "
+                                             f"total count: {self.total_example_count} | "
                                              f"shard({self.shard_count}): {self.example_count_in_shard}/{self.shard_size}")
 
                 print("")
@@ -100,15 +96,29 @@ class TfrecordMakerBase:
     def init_drive_tfrecord(self, drive_index=0):
         raise NotImplementedError()
 
-    def check_example_keys(self, first_example, example):
+    def verify_example(self, first_example, example):
+        if (not example) or ("image" not in example):
+            raise MyExceptionToCatch(f"[verify_example] EMPTY example")
+
         if not first_example:
             first_example = copy.deepcopy(example)
-        first_keys = [key for key, val in first_example.items() if val is not None]
-        curre_keys = [key for key, val in example.items() if val is not None]
-        if first_keys != curre_keys:
-            print(f"[WARNING] Count: {self.error_count}, Different keys: {list(first_keys)} != {list(curre_keys)}")
-            self.error_count += 1
-            assert self.error_count < 10
+            print("[verify_example] Set first_example:", list(first_example.keys()))
+            return first_example
+
+        for key in first_example:
+            if key not in example:
+                print(f"[verify_example] (WARNING) error count: {self.error_count}, {key} is not in example")
+                self.error_count += 1
+                assert self.error_count < 10
+                raise MyExceptionToCatch(f"{key} is not in example")
+
+            if first_example[key].shape != example[key].shape:
+                print(f"[verify_example] (WARNING) error count: {self.error_count}, "
+                      f"different shape of {key}: {first_example[key].get_shape()} != {example[key].get_shape()}")
+                self.error_count += 1
+                assert self.error_count < 10
+                raise MyExceptionToCatch(f"{key} is not in example")
+
         return first_example
 
     def write_tfrecord(self, example_serial, drive_index):

--- a/tfrecords/tfrecord_reader.py
+++ b/tfrecords/tfrecord_reader.py
@@ -69,6 +69,7 @@ class TfrecordReader:
         """
         file_pattern = f"{self.tfrpath}/*.tfrecord"
         filenames = tf.io.gfile.glob(file_pattern)
+        filenames.sort()
         print("[tfrecord reader]", file_pattern, filenames)
         dataset = tf.data.TFRecordDataset(filenames)
 
@@ -115,16 +116,20 @@ class TfrecordReader:
 # --------------------------------------------------------------------------------
 # TESTS
 
+
 def test_read_dataset():
     """
     Test if TfrecordReader works fine and print keys and shapes of input tensors
     """
-    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "kitti_raw_val"))
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "cityscapes_train"))
     dataset = tfrgen.get_dataset()
     for i, x in enumerate(dataset):
-        if i == 100:
-            break
-        print("===== index:", i)
+        # if i == 100:
+        #     break
+        uf.print_progress_status(f"===== index: {i}, imshape: {x['image'].get_shape()}")
+        # print("===== index:", i)
+        continue
+
         for key, value in x.items():
             print(f"x shape and type: {key}={value.shape}, {value.dtype}")
 

--- a/tfrecords/tfrecord_reader.py
+++ b/tfrecords/tfrecord_reader.py
@@ -128,13 +128,11 @@ def test_read_dataset():
         #     break
         uf.print_progress_status(f"===== index: {i}, imshape: {x['image'].get_shape()}")
         # print("===== index:", i)
-        continue
+        # for key, value in x.items():
+        #     print(f"x shape and type: {key}={value.shape}, {value.dtype}")
 
-        for key, value in x.items():
-            print(f"x shape and type: {key}={value.shape}, {value.dtype}")
-
-        print("stereo pose\n", x["stereo_T_LR"][0].numpy())
-        print("gt poses:\n", x['pose_gt'].numpy()[0])
+        # print("stereo pose\n", x["stereo_T_LR"][0].numpy())
+        # print("gt poses:\n", x['pose_gt'].numpy()[0])
         image = tf.image.convert_image_dtype((x["image"] + 1.)/2., dtype=tf.uint8).numpy()
         image5d = tf.image.convert_image_dtype((x["image5d"] + 1.) / 2., dtype=tf.uint8).numpy()
         cv2.imshow("image", image[0])

--- a/utils/util_class.py
+++ b/utils/util_class.py
@@ -7,7 +7,6 @@ class MyExceptionToCatch(Exception):
         super().__init__(msg)
 
 
-
 class WrongInputException(Exception):
     def __init__(self, msg):
         super().__init__(msg)


### PR DESCRIPTION
## config-example.py

cityscapes extra 데이터셋이 프레임간격이 너무커서 VODE에 적합하지 않음
모든 데이터셋 목록에서 제거

## logger.py

epoch에 따라 log가 정렬이 되도록 수정

## example_maker.py

유효하지 않은 데이터를 dict() 가 아닌 MyExceptionToCatch 로 처리

## tfrecord_maker.py

tfr_config.txt 가 잘 나오도록 first_example과 example을 비교검증
