### PR TITLE
Test training plans and upgrade depth map

### DIFF
--- a/model/loss_and_metric/loss_factory.py
+++ b/model/loss_and_metric/loss_factory.py
@@ -1,32 +1,34 @@
+import tensorflow as tf
 from config import opts
 import model.loss_and_metric.losses as lm
 
 
-def loss_factory(dataset_cfg, loss_weights, stereo=opts.STEREO,
+def loss_factory(dataset_cfg, loss_weights, scale_weights, stereo=opts.STEREO,
                  weights_to_regularize=None, batch_size=opts.BATCH_SIZE):
+    scale_weights = tf.convert_to_tensor(scale_weights.reshape(scale_weights.shape[0], 1), dtype=tf.float32)
     loss_pool = {
-        "L1": lm.PhotometricLossMultiScale("L1"),
-        "L1_R": lm.PhotometricLossMultiScale("L1", key_suffix="_R"),
-        "SSIM": lm.PhotometricLossMultiScale("SSIM"),
-        "SSIM_R": lm.PhotometricLossMultiScale("SSIM", key_suffix="_R"),
+        "L1": lm.PhotometricLossMultiScale("L1", scale_weights),
+        "L1_R": lm.PhotometricLossMultiScale("L1", scale_weights, key_suffix="_R"),
+        "SSIM": lm.PhotometricLossMultiScale("SSIM", scale_weights),
+        "SSIM_R": lm.PhotometricLossMultiScale("SSIM", scale_weights, key_suffix="_R"),
 
-        "md2L1": lm.MonoDepth2LossMultiScale("L1"),
-        "md2L1_R": lm.MonoDepth2LossMultiScale("L1", key_suffix="_R"),
-        "md2SSIM": lm.MonoDepth2LossMultiScale("SSIM"),
-        "md2SSIM_R": lm.MonoDepth2LossMultiScale("SSIM", key_suffix="_R"),
+        "md2L1": lm.MonoDepth2LossMultiScale("L1", scale_weights),
+        "md2L1_R": lm.MonoDepth2LossMultiScale("L1", scale_weights, key_suffix="_R"),
+        "md2SSIM": lm.MonoDepth2LossMultiScale("SSIM", scale_weights),
+        "md2SSIM_R": lm.MonoDepth2LossMultiScale("SSIM", scale_weights, key_suffix="_R"),
 
-        "cmbL1": lm.CombinedLossMultiScale("L1"),
-        "cmbL1_R": lm.CombinedLossMultiScale("L1", key_suffix="_R"),
-        "cmbSSIM": lm.CombinedLossMultiScale("SSIM"),
-        "cmbSSIM_R": lm.CombinedLossMultiScale("SSIM", key_suffix="_R"),
+        "cmbL1": lm.CombinedLossMultiScale("L1", scale_weights),
+        "cmbL1_R": lm.CombinedLossMultiScale("L1", scale_weights, key_suffix="_R"),
+        "cmbSSIM": lm.CombinedLossMultiScale("SSIM", scale_weights),
+        "cmbSSIM_R": lm.CombinedLossMultiScale("SSIM", scale_weights, key_suffix="_R"),
 
-        "smoothe": lm.SmoothenessLossMultiScale(),
-        "smoothe_R": lm.SmoothenessLossMultiScale(key_suffix="_R"),
-        "stereoL1": lm.StereoDepthLoss("L1"),
-        "stereoSSIM": lm.StereoDepthLoss("SSIM"),
+        "smoothe": lm.SmoothenessLossMultiScale(scale_weights),
+        "smoothe_R": lm.SmoothenessLossMultiScale(scale_weights, key_suffix="_R"),
+        "stereoL1": lm.StereoDepthLoss("L1", scale_weights),
+        "stereoSSIM": lm.StereoDepthLoss("SSIM", scale_weights),
         "stereoPose": lm.StereoPoseLoss(),
-        "flowL2": lm.FlowWarpLossMultiScale("L2"),
-        "flowL2_R": lm.FlowWarpLossMultiScale("L2", key_suffix="_R"),
+        "flowL2": lm.FlowWarpLossMultiScale("L2", scale_weights),
+        "flowL2_R": lm.FlowWarpLossMultiScale("L2", scale_weights, key_suffix="_R"),
         "flow_reg": lm.L2Regularizer(weights_to_regularize),
     }
     losses = dict()
@@ -41,6 +43,7 @@ def loss_factory(dataset_cfg, loss_weights, stereo=opts.STEREO,
         weights[name] = weight
 
     print("[loss_factory] loss weights:", weights)
+    print("[loss_factory] scale weights:", scale_weights[:, 0])
     return lm.TotalLoss(losses, weights, stereo, batch_size)
 
 

--- a/model/model_main.py
+++ b/model/model_main.py
@@ -189,5 +189,5 @@ def test_npz():
 if __name__ == "__main__":
     train_by_plan(opts.PRE_TRAINING_PLAN)
     # train_by_plan(opts.FINE_TRAINING_PLAN)
-    predict_by_plan()
+    # predict_by_plan()
 

--- a/model/model_util/logger.py
+++ b/model/model_util/logger.py
@@ -199,7 +199,7 @@ def stack_reconstruction_images(total_loss, features, predictions, indices):
 
     if "depth_ms" in predictions:
         target_depth = predictions["depth_ms"][0][batchidx]
-        target_depth = tf.clip_by_value(target_depth, 0., 20.) / 10. - 1.
+        # target_depth = tf.clip_by_value(target_depth, 0., 20.) / 10. - 1.
         view_imgs["target_depth"] = target_depth
 
     view_imgs[f"source_{srcidx}"] = augm_data["source"][batchidx, srcidx]

--- a/model/train_val.py
+++ b/model/train_val.py
@@ -43,6 +43,9 @@ class TrainValBase:
     def run_an_epoch(self, dataset):
         results = []
         for step, features in enumerate(dataset):
+            if step >= 25000:
+                print("! ! ! stop training at 25000 ! ! !")
+                break
             start = time.time()
             preds, loss, loss_by_type = self.run_a_batch(features)
             batch_result, log_msg = merge_results(features, preds, loss, loss_by_type, self.stereo)

--- a/model/train_val.py
+++ b/model/train_val.py
@@ -43,9 +43,6 @@ class TrainValBase:
     def run_an_epoch(self, dataset):
         results = []
         for step, features in enumerate(dataset):
-            if step >= 25000:
-                print("! ! ! stop training at 25000 ! ! !")
-                break
             start = time.time()
             preds, loss, loss_by_type = self.run_a_batch(features)
             batch_result, log_msg = merge_results(features, preds, loss, loss_by_type, self.stereo)

--- a/tfrecords/example_maker.py
+++ b/tfrecords/example_maker.py
@@ -150,9 +150,10 @@ class ExampleMaker:
             return False
 
     def load_intrinsic(self, index, rawshape_hw, rszshape_hw, right=False):
-        intrinsic = self.data_reader.get_intrinsic(index, right=right)
-        if intrinsic is None:
+        intrinsic_raw = self.data_reader.get_intrinsic(index, right=right)
+        if intrinsic_raw is None:
             return None
+        intrinsic = intrinsic_raw.copy()
         # scale fx, cx
         intrinsic[0] = intrinsic[0] * rszshape_hw[1] / rawshape_hw[1]
         # scale fy, cy
@@ -178,9 +179,9 @@ class ExampleMaker:
         if intrinsic is None: return None
         intrinsic_rsz = self.rescale_intrinsic(intrinsic, rawshape_hw, rszshape_hw)
         point_cloud = self.data_reader.get_point_cloud(index, right)
+        if point_cloud is None: return None
         depth_map = point_cloud_to_depth_map(point_cloud, intrinsic_rsz, rszshape_hw)
         # depth_map = self.data_reader.get_depth(index, rawshape_hw, rszshape_hw, intrinsic, right)
-        if depth_map is None: return None
         return depth_map.astype(np.float32)
 
     def rescale_intrinsic(self, intrinsic, rawshape_hw, rszshape_hw):

--- a/tfrecords/readers/a2d2_reader.py
+++ b/tfrecords/readers/a2d2_reader.py
@@ -102,7 +102,7 @@ class A2D2Reader(DataReaderBase):
         intrinsic = self.get_intrinsic(index, right)
         key = "depth_gt_R" if right else "depth_gt"
         depth_map = self.get_frame_data(index, key)
-        assert (intrinsic.shape == (3, 3)) and (depth_map.ndim == 2)
+        assert (intrinsic.shape == (3, 3)) and (depth_map.ndim == 2), f"[A2D2.get_point_cloud] {intrinsic}, {depth_map.shape}"
         point_cloud = depth_map_to_point_cloud(depth_map, intrinsic)
         return point_cloud
 
@@ -191,8 +191,8 @@ class A2D2Reader(DataReaderBase):
 
         depth_map = np.zeros(imsize_hw, dtype=np.float32)
         depth_map[lidar_row, lidar_col] = lidar_depth
-        # depth is supposed to have shape [H, W, 1]
-        return depth_map[:, :, np.newaxis]
+        # depth is supposed to have shape [H, W]
+        return depth_map
 
 
 class SensorConfig:

--- a/tfrecords/readers/a2d2_reader.py
+++ b/tfrecords/readers/a2d2_reader.py
@@ -9,7 +9,7 @@ import json
 import cv2
 
 from tfrecords.readers.reader_base import DataReaderBase
-from tfrecords.tfr_util import resize_depth_map
+from tfrecords.tfr_util import resize_depth_map, depth_map_to_point_cloud
 from utils.util_funcs import print_progress_status
 
 
@@ -97,6 +97,14 @@ class A2D2Reader(DataReaderBase):
 
     def get_pose(self, index, right=False):
         return None
+
+    def get_point_cloud(self, index, right=False):
+        intrinsic = self.get_intrinsic(index, right)
+        key = "depth_gt_R" if right else "depth_gt"
+        depth_map = self.get_frame_data(index, key)
+        assert (intrinsic.shape == (3, 3)) and (depth_map.ndim == 2)
+        point_cloud = depth_map_to_point_cloud(depth_map, intrinsic)
+        return point_cloud
 
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
         key = "depth_gt_R" if right else "depth_gt"

--- a/tfrecords/readers/city_reader.py
+++ b/tfrecords/readers/city_reader.py
@@ -45,7 +45,7 @@ class CityscapesReader(DataReaderBase):
             sub_drive_indices = [fi for fi, frame in enumerate(self.frame_names) if frame.startswith(sub_drive)]
             sub_drive_indices.sort()
             # remove first and last two frames in sub-drives
-            sub_drive_indices = sub_drive_indices[2:-2]
+            sub_drive_indices = sub_drive_indices[4:-4]
             if sub_drive_indices:
                 self.target_indices.extend(sub_drive_indices)
 

--- a/tfrecords/readers/city_reader.py
+++ b/tfrecords/readers/city_reader.py
@@ -7,6 +7,9 @@ from utils.util_class import MyExceptionToCatch
 from tfrecords.readers.reader_base import DataReaderBase
 from tfrecords.tfr_util import resize_depth_map, depth_map_to_point_cloud
 
+# pre-crop range to remove vehicle and blurred region in images [sy, ey, sx, ex]
+CITY_CROP = [0, 750, 48, 2048]
+
 
 class CityscapesReader(DataReaderBase):
     def __init__(self, split="", reader_arg=None):
@@ -58,6 +61,8 @@ class CityscapesReader(DataReaderBase):
         image = Image.open(image_bytes)
         image = np.array(image, np.uint8)
         image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+        image = image[CITY_CROP[0]:CITY_CROP[1], CITY_CROP[2]:CITY_CROP[3]]
+        assert image.shape[:2] == (CITY_CROP[1] - CITY_CROP[0], CITY_CROP[3] - CITY_CROP[2])
         return image
 
     def get_pose(self, index, right=False):
@@ -79,10 +84,13 @@ class CityscapesReader(DataReaderBase):
             disp[disp > 0] = (disp[disp > 0] - 1) / 256.
             depth = np.zeros(disp.shape, dtype=np.float32)
             depth[disp > 0] = (fx * baseline) / disp[disp > 0]     # depth = baseline * focal length / disparity
+            depth = depth[CITY_CROP[0]:CITY_CROP[1], CITY_CROP[2]:CITY_CROP[3]]
+            assert depth.shape[:2] == (CITY_CROP[1] - CITY_CROP[0], CITY_CROP[3] - CITY_CROP[2])
             point_cloud = depth_map_to_point_cloud(depth, intrinsic)
             return point_cloud
 
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
+        # DEPRECATED!
         if right: return None
         params = self._get_camera_param(index)
         baseline = params["extrinsic"]["baseline"]
@@ -105,8 +113,8 @@ class CityscapesReader(DataReaderBase):
         params = self._get_camera_param(index)
         fx = params["intrinsic"]["fx"]
         fy = params["intrinsic"]["fy"]
-        cx = params["intrinsic"]["u0"]
-        cy = params["intrinsic"]["v0"]
+        cx = params["intrinsic"]["u0"] - CITY_CROP[2]
+        cy = params["intrinsic"]["v0"] - CITY_CROP[0]
         intrinsic = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
         return intrinsic.astype(np.float32)
 

--- a/tfrecords/readers/kitti_reader.py
+++ b/tfrecords/readers/kitti_reader.py
@@ -306,6 +306,9 @@ class KittiOdomReader(DataReaderBase):
         else:
             return T_w_cam2.astype(np.float32)
 
+    def get_point_cloud(self, index, right=False):
+        return None
+
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
         return None
 

--- a/tfrecords/readers/kitti_reader.py
+++ b/tfrecords/readers/kitti_reader.py
@@ -65,6 +65,25 @@ class KittiRawReader(DataReaderBase):
         else:
             return T_w_cam2.astype(np.float32)
 
+    def get_point_cloud(self, index, right=False):
+        if index >= len(self.drive_loader.velo_files):
+            raise StopIteration("[get_point_cloud] index out of velo_files")
+        velo_file = self.drive_loader.velo_files[index]
+        velo_index = int(op.basename(velo_file)[:-4])
+        if index != velo_index:
+            raise StopIteration(f"[get_point_cloud] index does NOT match velo file ID {index} != {velo_index}")
+
+        velo_in_lidar = self.drive_loader.get_velo(index)
+        T2cam = self.drive_loader.calib.T_cam3_velo if right else self.drive_loader.calib.T_cam2_velo
+        # velodyne raw data [N, 4] is (forward, left, up, reflectance(0)->1)
+        velo_in_lidar[:, 3] = 1
+        # points in camera frame [N, 3] (right, down, forward)
+        velo_in_camera = np.dot(T2cam, velo_in_lidar.T)
+        velo_in_camera = velo_in_camera[:3].T
+        # remove all velodyne points behind image plane
+        velo_in_camera = velo_in_camera[velo_in_camera[:, 2] > 0]
+        return velo_in_camera
+
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
         if index >= len(self.drive_loader.velo_files):
             raise StopIteration("[get_depth] index out of velo_files")
@@ -219,7 +238,7 @@ def sub2ind(matrixSize, rowSub, colSub):
     m, n = matrixSize
     return rowSub * (n - 1) + colSub - 1
 
-# TODO ======================================================================
+# ======================================================================
 
 
 class KittiOdomReader(DataReaderBase):

--- a/tfrecords/readers/reader_base.py
+++ b/tfrecords/readers/reader_base.py
@@ -43,6 +43,12 @@ class DataReaderBase:
         """
         raise NotImplementedError()
 
+    def get_point_cloud(self, index, right=False):
+        """
+        :return: point cloud in standard camera frame (X=right, Y=down, Z=front)
+        """
+        raise NotImplementedError()
+
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):
         """
         :return: indexed pose in a vector [position, quaternion] in the current sequence

--- a/tfrecords/readers/waymo_reader.py
+++ b/tfrecords/readers/waymo_reader.py
@@ -75,11 +75,11 @@ class WaymoReader(DataReaderBase):
         cam1_T_V2C = np.linalg.inv(cam1_T_C2V)
         points_veh_homo = np.concatenate((points_veh, np.ones((points_veh.shape[0], 1))), axis=1)
         points_veh_homo = points_veh_homo.T
-        # point_cam_homo [N, 4] (front, left, up, 1)
+        # point_cam_homo [4, N] (front, left, up, 1)
         points_cam_homo = cam1_T_V2C @ points_veh_homo
         # rotation: (front, left, up, 1) -> (right, down, front)
         R = np.array([[0, -1, 0, 0], [0, 0, -1, 0], [1, 0, 0, 0]], dtype=np.float32)
-        points_cam_standard = (R @ points_cam_homo.T).T
+        points_cam_standard = (R @ points_cam_homo).T
         return points_cam_standard
 
     def get_depth(self, index, srcshape_hw, dstshape_hw, intrinsic, right=False):

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -6,8 +6,6 @@ import shutil
 import json
 import copy
 from timeit import default_timer as timer
-import numpy as np
-import cv2
 
 import utils.util_funcs as uf
 import utils.util_class as uc
@@ -69,8 +67,6 @@ class TfrecordMakerBase:
                 first_example = dict()
 
                 for ii, index in enumerate(loop_range):
-                    if ii % 10 != 0:
-                        continue
                     time1 = timer()
                     if (frame_per_drive > 0) and (self.example_count_in_drive >= frame_per_drive):
                         break

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -6,6 +6,8 @@ import shutil
 import json
 import copy
 from timeit import default_timer as timer
+import numpy as np
+import cv2
 
 import utils.util_funcs as uf
 import utils.util_class as uc
@@ -67,6 +69,8 @@ class TfrecordMakerBase:
                 first_example = dict()
 
                 for ii, index in enumerate(loop_range):
+                    if ii % 10 != 0:
+                        continue
                     time1 = timer()
                     if (frame_per_drive > 0) and (self.example_count_in_drive >= frame_per_drive):
                         break

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 import shutil
 import json
 import copy
+from timeit import default_timer as timer
 
 import utils.util_funcs as uf
 import utils.util_class as uc
@@ -66,6 +67,7 @@ class TfrecordMakerBase:
                 first_example = dict()
 
                 for ii, index in enumerate(loop_range):
+                    time1 = timer()
                     if (frame_per_drive > 0) and (self.example_count_in_drive >= frame_per_drive):
                         break
                     if (total_frame_limit > 0) and (self.total_example_count >= total_frame_limit):
@@ -86,7 +88,8 @@ class TfrecordMakerBase:
                     uf.print_progress_status(f"==[making TFR] drives: {di}/{num_drives} | "
                                              f"index,count: {ii}/{self.example_count_in_drive}/{num_frames} | "
                                              f"total count: {self.total_example_count} | "
-                                             f"shard({self.shard_count}): {self.example_count_in_shard}/{self.shard_size}")
+                                             f"shard({self.shard_count}): {self.example_count_in_shard}/{self.shard_size} | "
+                                             f"time: {timer() - time1:1.4f}")
 
                 print("")
                 self.write_tfrecord_config(first_example)

--- a/tfrecords/tfrecord_maker.py
+++ b/tfrecords/tfrecord_maker.py
@@ -243,9 +243,6 @@ class DrivingStereoTfrecordMaker(TfrecordMakerSingleDir):
         drive_paths.sort()
         return drive_paths
 
-# TODO ======================================================================
-# TfrecordMakers which make tfrecords in drive sub-dir under tfrpath and move them to tfrpath when finished
-
 
 class WaymoTfrecordMaker(TfrecordMakerBase):
     def __init__(self, dataset, split, srcpath, tfrpath, shard_size, stereo, shwc_shape):

--- a/tfrecords/tfrecord_reader.py
+++ b/tfrecords/tfrecord_reader.py
@@ -121,7 +121,7 @@ def test_read_dataset():
     """
     Test if TfrecordReader works fine and print keys and shapes of input tensors
     """
-    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "cityscapes_train"))
+    tfrgen = TfrecordReader(op.join(opts.DATAPATH_TFR, "a2d2_train"))
     dataset = tfrgen.get_dataset()
     for i, x in enumerate(dataset):
         # if i == 100:
@@ -134,9 +134,7 @@ def test_read_dataset():
         # print("stereo pose\n", x["stereo_T_LR"][0].numpy())
         # print("gt poses:\n", x['pose_gt'].numpy()[0])
         image = tf.image.convert_image_dtype((x["image"] + 1.)/2., dtype=tf.uint8).numpy()
-        image5d = tf.image.convert_image_dtype((x["image5d"] + 1.) / 2., dtype=tf.uint8).numpy()
         cv2.imshow("image", image[0])
-        cv2.imshow("target", image5d[0, -1])
         cv2.waitKey()
 
 

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -202,9 +202,13 @@ def stack_titled_images(view_imgs, guide_lines=True):
 
     for name, flimage in view_imgs.items():
         flimage_rsz = tf.image.resize(flimage, size=hw_size, method="nearest")
-        u8image = to_uint8_image(flimage_rsz).numpy()
-        if u8image.shape[-1] == 1:
-            u8image = cv2.cvtColor(u8image, cv2.COLOR_GRAY2BGR)
+        if "depth" in name:
+            u8image = (np.clip(flimage_rsz, 0, 50.) / 50. * 256).astype(np.uint8)
+            u8image = cv2.applyColorMap(u8image, cv2.COLORMAP_VIRIDIS)
+        else:
+            u8image = to_uint8_image(flimage_rsz).numpy()
+            if u8image.shape[-1] == 1:
+                u8image = cv2.cvtColor(u8image, cv2.COLOR_GRAY2BGR)
         cv2.putText(u8image, name, location, font, font_scale, color, thickness)
         view.append(u8image)
 

--- a/utils/util_funcs.py
+++ b/utils/util_funcs.py
@@ -203,8 +203,8 @@ def stack_titled_images(view_imgs, guide_lines=True):
     for name, flimage in view_imgs.items():
         flimage_rsz = tf.image.resize(flimage, size=hw_size, method="nearest")
         if "depth" in name:
-            u8image = (np.clip(flimage_rsz, 0, 50.) / 50. * 256).astype(np.uint8)
-            u8image = cv2.applyColorMap(u8image, cv2.COLORMAP_VIRIDIS)
+            u8image = ((np.clip(flimage_rsz, 10, 50) - 10.) / 40. * 256.).astype(np.uint8)
+            u8image = cv2.cvtColor(u8image, cv2.COLOR_GRAY2BGR)
         else:
             u8image = to_uint8_image(flimage_rsz).numpy()
             if u8image.shape[-1] == 1:


### PR DESCRIPTION
## Apply scale_weights

1, 1/2, 1/4, 1/8 스케일에 대해 각기 다른 loss weight를 적용하도록 수정

### config

- SCALE_WEIGHT_T1, SCALE_WEIGHT_T2 두 가지 타입 만들고
- TRAINING_PLAN에 둘 중 하나 끼워넣기

### model_main, loss_factory, losses

- model_main, loss_factory: loss 객체에 scale_weights 전달
- losses: scale_weights를 scale 별로 loss에 곱하여 합산

## Upgrade depth map

bilinear interpolation을 통해 point cloud를 depth map으로 정확하게 변환하는 함수 적용하도록
그동안은 원본 이미지 해상도의 depth map을 만들거나 불러오고 이를 축소해서 목표 해상도의 depth map을 만들었지만
3d point가 floating point pixel이 되었을때 이를 반올림처리하여 부정확한 측면이 있음
그리고 한 픽셀에 여러 점들이 들어올때 이를 정확하게 평균내지 못 함

3d point가 여러 픽셀에 걸쳐서 들어오고 한 픽셀에 여러 점들이 들어오는 상황에서 
interpolation을 통해 정확히 depth map 계산하는 알고리즘 개발
DataFrame의 `drop_duplicates()`와 `df = df[~df.index.isin(other.index)]`를 통해
중복되는 픽셀좌표들을 순차적으로 처리함

### tfr_util

- depth_map_to_point_cloud(): 원본 해상도 depth map이 있을시 이를 point cloud로 변환
- point_cloud_to_depth_map(): point cloud를 목표 해상도의 depth map으로 변환

### example_maker

- load_depth_map(): xxx_reader에서 depth map 대신 point cloud 받아와서 point_cloud_to_depth_map()으로 축소된 depth map 생성
- make_snippet_ids(): cityscapes, a2d2 데이터셋의 경우 프레임 간격이 좁아서 충분한 parallax 가 확보되지 않으므로 2프레임 간격으로 snippet을 만들도록 수정
- check_static_sequence(): (almost) static sequence를 제거하기 위해 여러시도를 했으나 결국은 실패, 지난 시도는 commit log를 보면 복원할 수 있다.

### xxx_reader(s)

- get_point_cloud 함수 구현, depth map 있을시 depth_map_to_point_cloud() 사용
- 안정화되면 get_depth() 함수와 관련 함수들을 지워야 함
